### PR TITLE
Feat/13 글 작성 페이지 UI, 스티커 넣기 기능 규현

### DIFF
--- a/MacC-GoldenRatio/MacC-GoldenRatio.xcodeproj/project.pbxproj
+++ b/MacC-GoldenRatio/MacC-GoldenRatio.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0A5E904828E857E200B381B8 /* StickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E904728E857E200B381B8 /* StickerView.swift */; };
 		0A5E904A28E858C000B381B8 /* StickerContollerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E904928E858C000B381B8 /* StickerContollerView.swift */; };
 		0A5E904C28E858D200B381B8 /* StickerBorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E904B28E858D200B381B8 /* StickerBorderView.swift */; };
+		0A5E904F28E9948B00B381B8 /* PageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E904E28E9948B00B381B8 /* PageViewModel.swift */; };
 		E243425C28E4B890007BB6DE /* MyDiariesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E243425B28E4B890007BB6DE /* MyDiariesViewController.swift */; };
 		E276B91C28E46AE900163833 /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E276B91B28E46AE900163833 /* UserModel.swift */; };
 		E276B91E28E46B3700163833 /* DiaryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E276B91D28E46B3700163833 /* DiaryModel.swift */; };
@@ -76,6 +77,7 @@
 		0A5E904728E857E200B381B8 /* StickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerView.swift; sourceTree = "<group>"; };
 		0A5E904928E858C000B381B8 /* StickerContollerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerContollerView.swift; sourceTree = "<group>"; };
 		0A5E904B28E858D200B381B8 /* StickerBorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerBorderView.swift; sourceTree = "<group>"; };
+		0A5E904E28E9948B00B381B8 /* PageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewModel.swift; sourceTree = "<group>"; };
 		E243425B28E4B890007BB6DE /* MyDiariesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyDiariesViewController.swift; sourceTree = "<group>"; };
 		E276B91B28E46AE900163833 /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
 		E276B91D28E46B3700163833 /* DiaryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryModel.swift; sourceTree = "<group>"; };
@@ -153,6 +155,14 @@
 			path = Sticker;
 			sourceTree = "<group>";
 		};
+		0A5E904D28E9947800B381B8 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				0A5E904E28E9948B00B381B8 /* PageViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		E276B91328E468D700163833 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -202,6 +212,7 @@
 		E276B91928E4697900163833 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				0A5E904D28E9947800B381B8 /* ViewModels */,
 				E276B91B28E46AE900163833 /* UserModel.swift */,
 				E276B91D28E46B3700163833 /* DiaryModel.swift */,
 			);
@@ -442,6 +453,7 @@
 				E276B92028E4812E00163833 /* UIScreen+.swift in Sources */,
 				E2EA7F0E28E56EDF00AC1C49 /* DiaryCollectionViewCell.swift in Sources */,
 				0A5E904C28E858D200B381B8 /* StickerBorderView.swift in Sources */,
+				0A5E904F28E9948B00B381B8 /* PageViewModel.swift in Sources */,
 				E2EA7F0A28E56CFE00AC1C49 /* MyAlbumsViewController.swift in Sources */,
 				0A5E904A28E858C000B381B8 /* StickerContollerView.swift in Sources */,
 				E276B91E28E46B3700163833 /* DiaryModel.swift in Sources */,

--- a/MacC-GoldenRatio/MacC-GoldenRatio.xcodeproj/project.pbxproj
+++ b/MacC-GoldenRatio/MacC-GoldenRatio.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A5E904528E8578400B381B8 /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E904428E8578400B381B8 /* PageViewController.swift */; };
+		0A5E904828E857E200B381B8 /* StickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E904728E857E200B381B8 /* StickerView.swift */; };
+		0A5E904A28E858C000B381B8 /* StickerContollerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E904928E858C000B381B8 /* StickerContollerView.swift */; };
+		0A5E904C28E858D200B381B8 /* StickerBorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E904B28E858D200B381B8 /* StickerBorderView.swift */; };
 		E243425C28E4B890007BB6DE /* MyDiariesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E243425B28E4B890007BB6DE /* MyDiariesViewController.swift */; };
 		E276B91C28E46AE900163833 /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E276B91B28E46AE900163833 /* UserModel.swift */; };
 		E276B91E28E46B3700163833 /* DiaryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E276B91D28E46B3700163833 /* DiaryModel.swift */; };
@@ -68,6 +72,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0A5E904428E8578400B381B8 /* PageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewController.swift; sourceTree = "<group>"; };
+		0A5E904728E857E200B381B8 /* StickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerView.swift; sourceTree = "<group>"; };
+		0A5E904928E858C000B381B8 /* StickerContollerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerContollerView.swift; sourceTree = "<group>"; };
+		0A5E904B28E858D200B381B8 /* StickerBorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerBorderView.swift; sourceTree = "<group>"; };
 		E243425B28E4B890007BB6DE /* MyDiariesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyDiariesViewController.swift; sourceTree = "<group>"; };
 		E276B91B28E46AE900163833 /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
 		E276B91D28E46B3700163833 /* DiaryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryModel.swift; sourceTree = "<group>"; };
@@ -127,6 +135,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0A5E904328E8575C00B381B8 /* Page */ = {
+			isa = PBXGroup;
+			children = (
+				0A5E904428E8578400B381B8 /* PageViewController.swift */,
+			);
+			path = Page;
+			sourceTree = "<group>";
+		};
+		0A5E904628E857BB00B381B8 /* Sticker */ = {
+			isa = PBXGroup;
+			children = (
+				0A5E904728E857E200B381B8 /* StickerView.swift */,
+				0A5E904928E858C000B381B8 /* StickerContollerView.swift */,
+				0A5E904B28E858D200B381B8 /* StickerBorderView.swift */,
+			);
+			path = Sticker;
+			sourceTree = "<group>";
+		};
 		E276B91328E468D700163833 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -185,6 +211,7 @@
 		E276B91A28E4697E00163833 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				0A5E904328E8575C00B381B8 /* Page */,
 				E2EA7F0428E56BD700AC1C49 /* Main */,
 				E28F080528E4655100832F4A /* ViewController.swift */,
 			);
@@ -255,6 +282,7 @@
 		E2EA7F1428E570F100AC1C49 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0A5E904628E857BB00B381B8 /* Sticker */,
 				E2EA7F1528E5711E00AC1C49 /* DiaryCollectionHeaderView.swift */,
 			);
 			path = Views;
@@ -408,15 +436,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				E28F080628E4655100832F4A /* ViewController.swift in Sources */,
+				0A5E904528E8578400B381B8 /* PageViewController.swift in Sources */,
 				E2EA7F0628E56C0900AC1C49 /* TabBarController.swift in Sources */,
 				E2EA7F0828E56CF600AC1C49 /* MyPlacesViewController.swift in Sources */,
 				E276B92028E4812E00163833 /* UIScreen+.swift in Sources */,
 				E2EA7F0E28E56EDF00AC1C49 /* DiaryCollectionViewCell.swift in Sources */,
+				0A5E904C28E858D200B381B8 /* StickerBorderView.swift in Sources */,
 				E2EA7F0A28E56CFE00AC1C49 /* MyAlbumsViewController.swift in Sources */,
+				0A5E904A28E858C000B381B8 /* StickerContollerView.swift in Sources */,
 				E276B91E28E46B3700163833 /* DiaryModel.swift in Sources */,
 				E2EA7F0C28E56DF600AC1C49 /* MyPageViewController.swift in Sources */,
 				E28F080228E4655100832F4A /* AppDelegate.swift in Sources */,
 				E276B91C28E46AE900163833 /* UserModel.swift in Sources */,
+				0A5E904828E857E200B381B8 /* StickerView.swift in Sources */,
 				E2EA7F1628E5711E00AC1C49 /* DiaryCollectionHeaderView.swift in Sources */,
 				E28F080428E4655100832F4A /* SceneDelegate.swift in Sources */,
 				E243425C28E4B890007BB6DE /* MyDiariesViewController.swift in Sources */,

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/UIScreen+.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/UIScreen+.swift
@@ -10,10 +10,8 @@ import UIKit
 extension UIScreen {
 	static func getDevice() -> DeviceSize {
 		if UIScreen.main.bounds.size.width == 428 {
-            // 14 plus, 14 pro max
 			return DeviceSize.iPhone13ProMax
 		} else if UIScreen.main.bounds.size.width == 390 {
-            // 14, 14 pro
 			return DeviceSize.iPhone13
 		} else if UIScreen.main.bounds.size.width == 375 {
 			return DeviceSize.iPhoneMini

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/UIScreen+.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/UIScreen+.swift
@@ -10,8 +10,10 @@ import UIKit
 extension UIScreen {
 	static func getDevice() -> DeviceSize {
 		if UIScreen.main.bounds.size.width == 428 {
+            // 14 plus, 14 pro max
 			return DeviceSize.iPhone13ProMax
 		} else if UIScreen.main.bounds.size.width == 390 {
+            // 14, 14 pro
 			return DeviceSize.iPhone13
 		} else if UIScreen.main.bounds.size.width == 375 {
 			return DeviceSize.iPhoneMini
@@ -159,6 +161,62 @@ extension UIScreen {
 			default: return 20
 			}
 		}
+        
+        // MARK: Page
+        var pagePadding: CGFloat {
+            switch self {
+            default: return CGFloat(10)
+            }
+        }
+        
+        var pageToolButtonInterval: CGFloat {
+            switch self {
+            default: return CGFloat(10)
+            }
+        }
+
+        var pageDescriptionLabelFont: UIFont {
+            switch self {
+            default: return UIFont.systemFont(ofSize: 17, weight: .regular)
+            }
+        }
+        
+        var pageToolButtonSize: CGSize {
+            switch self {
+            default: return CGSize(width: 30, height: 30)
+            }
+        }
+        
+        var pageToolButtonPointSize: CGFloat {
+            switch self {
+            default: return CGFloat(18)
+            }
+        }
+        
+        // MARK: Sticker
+        var stickerDefaultSize: CGSize {
+            switch self {
+            default: return CGSize(width: 100, height: 100)
+            }
+        }
+        
+        var stickerControllerSize: CGSize {
+            switch self {
+            default: return CGSize(width: 22, height: 22)
+            }
+        }
+        
+        var stickerBorderWidth: CGFloat {
+            switch self {
+            default: return CGFloat(1)
+            }
+        }
+        
+        var stickerBorderInset: CGFloat {
+            switch self {
+            default: return CGFloat(5)
+            }
+        }
 	}
 
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Models/ViewModels/PageViewModel.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Models/ViewModels/PageViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  PageViewModel.swift
+//  MacC-GoldenRatio
+//
+//  Created by 김상현 on 2022/10/02.
+//
+
+import Foundation
+
+class PageViewModel {
+    static let pageViewModel = PageViewModel()
+    var stickerArray: [StickerView] = []
+    
+    func appendSticker(_ sticker: StickerView) {
+        stickerArray.append(sticker)
+        debugPrint(stickerArray)
+
+    }
+    
+    func removeSticker(_ sticker: StickerView) {
+        guard let index = stickerArray.firstIndex(of: sticker) else { return }
+        stickerArray.remove(at: index)
+        debugPrint(stickerArray)
+
+    }
+    
+    func hideStickerSubviews() {
+        stickerArray.forEach{
+            $0.subviewIsHidden = true
+        }
+        debugPrint(stickerArray)
+
+    }
+    
+    func bringStickerToFront(_ sticker: StickerView) {
+        guard let index = stickerArray.firstIndex(of: sticker) else { return }
+        stickerArray.remove(at: index)
+        stickerArray.append(sticker)
+        debugPrint(stickerArray)
+    }
+}

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Main/TabBarController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Main/TabBarController.swift
@@ -39,8 +39,9 @@ class TabBarController: UITabBarController {
 	}()
 	
 	private lazy var myPageViewController: UIViewController = {
-		let viewController = UINavigationController(rootViewController: MyPageViewController())
-		
+//		let viewController = UINavigationController(rootViewController: MyPageViewController())
+        let viewController = UINavigationController(rootViewController: PageViewController())
+
 		let tabBarItem = UITabBarItem(title: "", image: UIImage(systemName: "person"), tag: 4)
 		
 		viewController.tabBarItem = tabBarItem

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Main/TabBarController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Main/TabBarController.swift
@@ -39,7 +39,6 @@ class TabBarController: UITabBarController {
 	}()
 	
 	private lazy var myPageViewController: UIViewController = {
-//		let viewController = UINavigationController(rootViewController: MyPageViewController())
         let viewController = UINavigationController(rootViewController: PageViewController())
 
 		let tabBarItem = UITabBarItem(title: "", image: UIImage(systemName: "person"), tag: 4)

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
@@ -115,12 +115,9 @@ class PageViewController: UIViewController {
     }
     
     private func configureConstraints() {
-        [backgroundImageView, pageDescriptionLabel, mapToolButton, imageToolButton, stickerToolButton, textToolButton].forEach{
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        }
         
         backgroundImageView.snp.makeConstraints { make in
-            make.leading.top.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.edges.equalTo(view.safeAreaLayoutGuide)
         }
         
         pageDescriptionLabel.snp.makeConstraints { make in

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
@@ -10,8 +10,8 @@ import SnapKit
 
 class PageViewController: UIViewController {
     private let myDevice: UIScreen.DeviceSize = UIScreen.getDevice()
-    private var stickers: [StickerView] = []
-
+    private let pageViewModel = PageViewModel.pageViewModel
+    
     private lazy var backgroundImageView: UIImageView = {
         let backgroundImageView = UIImageView()
         backgroundImageView.backgroundColor = .gray
@@ -161,14 +161,12 @@ class PageViewController: UIViewController {
             self.backgroundImageView.addSubview(stickerView)
             self.backgroundImageView.bringSubviewToFront(stickerView)
             self.backgroundImageView.isUserInteractionEnabled = true
-            self.stickers.append(stickerView)
+            self.pageViewModel.appendSticker(stickerView)
         }
         
     }
     
     @objc private func setStickerSubviewIsHidden() {
-        stickers.forEach{
-            $0.subviewIsHidden = true
-        }
+        self.pageViewModel.hideStickerSubviews()
     }
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
@@ -1,0 +1,169 @@
+//
+//  PageViewController.swift
+//  MacC-GoldenRatio
+//
+//  Created by 김상현 on 2022/10/01.
+//
+
+import UIKit
+import SnapKit
+
+class PageViewController: UIViewController {
+    private var stickers: [StickerView] = []
+    private let pageDescriptionLabelFont: UIFont = UIFont.systemFont(ofSize: 17, weight: .regular)
+    private let toolSize: CGSize = CGSize(width: 30, height: 30)
+    private let toolButtonPointSize: CGFloat = 18
+
+    private lazy var backgroundImageView: UIImageView = {
+        let backgroundImageView = UIImageView()
+        backgroundImageView.backgroundColor = .gray
+        
+        return backgroundImageView
+    }()
+    
+    private lazy var pageDescriptionLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .black
+        label.font = pageDescriptionLabelFont
+        label.text = "1 / 15"
+        
+        return label
+    }()
+    
+    private lazy var mapToolButton: UIButton = {
+        let button = UIButton()
+        let image = UIImage(systemName: "map")
+        button.setImage(image, for: .normal)
+        button.tintColor = .black
+        
+        return button
+    }()
+    
+    private lazy var imageToolButton: UIButton = {
+        let button = UIButton()
+        let image = UIImage(systemName: "photo")
+        button.setImage(image, for: .normal)
+        button.tintColor = .black
+
+        return button
+    }()
+    
+    private lazy var stickerToolButton: UIButton = {
+        let button = UIButton()
+        let image = UIImage(systemName: "s.circle.fill")
+        button.setImage(image, for: .normal)
+        button.tintColor = .black
+        
+        return button
+    }()
+    
+    private lazy var textToolButton: UIButton = {
+        let button = UIButton()
+        let image = UIImage(systemName: "t.square")
+        button.setImage(image, for: .normal)
+        button.tintColor = .black
+
+        return button
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        DispatchQueue.main.async {
+            self.addSubviews()
+            self.configureBackgroundImageView()
+            self.configureToolButton()
+            self.configureConstraints()
+        }
+    }
+    
+    private func addSubviews() {
+        view.addSubview(backgroundImageView)
+        view.addSubview(pageDescriptionLabel)
+        [mapToolButton, imageToolButton, stickerToolButton, textToolButton].forEach{
+            view.addSubview($0)
+        }
+    }
+    
+    private func configureBackgroundImageView() {
+        let backgroundImageViewSingleTap = UITapGestureRecognizer(target: self, action: #selector(self.setStickerSubviewIsHidden))
+        self.backgroundImageView.addGestureRecognizer(backgroundImageViewSingleTap)
+    }
+    
+    private func configureToolButton() {
+        [mapToolButton, imageToolButton, stickerToolButton, textToolButton].forEach{
+            
+            let imageConfig = UIImage.SymbolConfiguration(pointSize: toolButtonPointSize)
+            if #available(iOS 15.0, *) {
+                var config = UIButton.Configuration.plain()
+                config.preferredSymbolConfigurationForImage = imageConfig
+                $0.configuration = config
+            } else {
+                $0.setPreferredSymbolConfiguration(imageConfig, forImageIn: .normal)
+            }
+            
+        }
+        self.mapToolButton.addTarget(self, action: #selector(self.addSticker), for: .touchUpInside)
+        self.imageToolButton.addTarget(self, action: #selector(self.addSticker), for: .touchUpInside)
+        self.stickerToolButton.addTarget(self, action: #selector(self.addSticker), for: .touchUpInside)
+        self.textToolButton.addTarget(self, action: #selector(self.addSticker), for: .touchUpInside)
+    }
+    
+    private func configureConstraints() {
+        [backgroundImageView, pageDescriptionLabel, mapToolButton, imageToolButton, stickerToolButton, textToolButton].forEach{
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        backgroundImageView.snp.makeConstraints { make in
+            make.leading.top.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        pageDescriptionLabel.snp.makeConstraints { make in
+            make.trailing.top.equalTo(backgroundImageView).inset(10)
+        }
+        
+        mapToolButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(10)
+            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(10)
+            make.size.equalTo(toolSize)
+        }
+        
+        imageToolButton.snp.makeConstraints { make in
+            make.leading.equalTo(mapToolButton.snp.trailing).offset(10)
+            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(10)
+            make.size.equalTo(toolSize)
+        }
+        
+        stickerToolButton.snp.makeConstraints { make in
+            make.leading.equalTo(imageToolButton.snp.trailing).offset(10)
+            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(10)
+            make.size.equalTo(toolSize)
+        }
+        
+        textToolButton.snp.makeConstraints { make in
+            make.leading.equalTo(stickerToolButton.snp.trailing).offset(10)
+            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(10)
+            make.size.equalTo(toolSize)
+        }
+    }
+    
+    // MARK: Actions
+    @objc private func addSticker() {
+        DispatchQueue.main.async {
+            let image = UIImage(systemName: "photo")!
+            let stickerView = StickerView(image: image, size: CGSize(width: 100, height: 100))
+            stickerView.center = self.backgroundImageView.center
+            self.backgroundImageView.addSubview(stickerView)
+            self.backgroundImageView.bringSubviewToFront(stickerView)
+            self.backgroundImageView.isUserInteractionEnabled = true
+            self.stickers.append(stickerView)
+        }
+        
+    }
+    
+    @objc private func setStickerSubviewIsHidden() {
+        stickers.forEach{
+            $0.subviewIsHidden = true
+        }
+    }
+}

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
@@ -9,10 +9,8 @@ import UIKit
 import SnapKit
 
 class PageViewController: UIViewController {
+    private let myDevice: UIScreen.DeviceSize = UIScreen.getDevice()
     private var stickers: [StickerView] = []
-    private let pageDescriptionLabelFont: UIFont = UIFont.systemFont(ofSize: 17, weight: .regular)
-    private let toolSize: CGSize = CGSize(width: 30, height: 30)
-    private let toolButtonPointSize: CGFloat = 18
 
     private lazy var backgroundImageView: UIImageView = {
         let backgroundImageView = UIImageView()
@@ -24,7 +22,7 @@ class PageViewController: UIViewController {
     private lazy var pageDescriptionLabel: UILabel = {
         let label = UILabel()
         label.textColor = .black
-        label.font = pageDescriptionLabelFont
+        label.font = myDevice.pageDescriptionLabelFont
         label.text = "1 / 15"
         
         return label
@@ -100,7 +98,7 @@ class PageViewController: UIViewController {
     private func configureToolButton() {
         [mapToolButton, imageToolButton, stickerToolButton, textToolButton].forEach{
             
-            let imageConfig = UIImage.SymbolConfiguration(pointSize: toolButtonPointSize)
+            let imageConfig = UIImage.SymbolConfiguration(pointSize: myDevice.pageToolButtonPointSize)
             if #available(iOS 15.0, *) {
                 var config = UIButton.Configuration.plain()
                 config.preferredSymbolConfigurationForImage = imageConfig
@@ -126,31 +124,31 @@ class PageViewController: UIViewController {
         }
         
         pageDescriptionLabel.snp.makeConstraints { make in
-            make.trailing.top.equalTo(backgroundImageView).inset(10)
+            make.trailing.top.equalTo(backgroundImageView).inset(myDevice.pagePadding)
         }
         
         mapToolButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(10)
-            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(10)
-            make.size.equalTo(toolSize)
+            make.leading.equalToSuperview().offset(myDevice.pagePadding)
+            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(myDevice.pagePadding)
+            make.size.equalTo(myDevice.pageToolButtonSize)
         }
         
         imageToolButton.snp.makeConstraints { make in
-            make.leading.equalTo(mapToolButton.snp.trailing).offset(10)
-            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(10)
-            make.size.equalTo(toolSize)
+            make.leading.equalTo(mapToolButton.snp.trailing).offset(myDevice.pageToolButtonInterval)
+            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(myDevice.pagePadding)
+            make.size.equalTo(myDevice.pageToolButtonSize)
         }
         
         stickerToolButton.snp.makeConstraints { make in
-            make.leading.equalTo(imageToolButton.snp.trailing).offset(10)
-            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(10)
-            make.size.equalTo(toolSize)
+            make.leading.equalTo(imageToolButton.snp.trailing).offset(myDevice.pageToolButtonInterval)
+            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(myDevice.pagePadding)
+            make.size.equalTo(myDevice.pageToolButtonSize)
         }
         
         textToolButton.snp.makeConstraints { make in
-            make.leading.equalTo(stickerToolButton.snp.trailing).offset(10)
-            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(10)
-            make.size.equalTo(toolSize)
+            make.leading.equalTo(stickerToolButton.snp.trailing).offset(myDevice.pageToolButtonInterval)
+            make.bottom.equalTo(backgroundImageView.snp.bottom).inset(myDevice.pagePadding)
+            make.size.equalTo(myDevice.pageToolButtonSize)
         }
     }
     
@@ -158,8 +156,8 @@ class PageViewController: UIViewController {
     @objc private func addSticker() {
         DispatchQueue.main.async {
             let image = UIImage(systemName: "photo")!
-            let stickerView = StickerView(image: image, size: CGSize(width: 100, height: 100))
-            stickerView.center = self.backgroundImageView.center
+            let stickerView = StickerView(image: image, size: self.myDevice.stickerDefaultSize)
+            stickerView.center = CGPoint(x: self.view.center.x, y: self.view.center.y - 100)
             self.backgroundImageView.addSubview(stickerView)
             self.backgroundImageView.bringSubviewToFront(stickerView)
             self.backgroundImageView.isUserInteractionEnabled = true

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Page/PageViewController.swift
@@ -69,6 +69,13 @@ class PageViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.tabBarController?.tabBar.isHidden = true
+        let leftBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: nil)
+        let rightBarButtonItem = UIBarButtonItem(title: "완료", style: .plain, target: self, action: nil)
+        self.navigationItem.title = "1일차"
+        self.navigationItem.setLeftBarButton(leftBarButtonItem, animated: false)
+        self.navigationItem.setRightBarButton(rightBarButtonItem, animated: false)
+        
         DispatchQueue.main.async {
             self.addSubviews()
             self.configureBackgroundImageView()

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerBorderView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerBorderView.swift
@@ -1,0 +1,42 @@
+//
+//  StickerBorderView.swift
+//  MacC-GoldenRatio
+//
+//  Created by 김상현 on 2022/10/01.
+//
+
+import UIKit
+
+/// StickerView의 테두리를 나타내는 사각형 뷰
+class StickerBorderView: UIView {
+    
+    override func draw(_ rect: CGRect) {
+        let context = UIGraphicsGetCurrentContext()
+        guard let context = context else { return }
+        context.saveGState()
+        context.setLineWidth(1)
+        let dash: [CGFloat] = [1.0, 0.0]
+        context.setLineDash(phase: 0.0, lengths: dash)
+        context.setStrokeColor(UIColor.black.cgColor)
+        context.addRect(rect)
+        context.strokePath()
+        context.restoreGState()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupView()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        setupView()
+    }
+
+    private func setupView() {
+        backgroundColor = UIColor.clear
+    }
+
+}

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerBorderView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerBorderView.swift
@@ -9,12 +9,13 @@ import UIKit
 
 /// StickerView의 테두리를 나타내는 사각형 뷰
 class StickerBorderView: UIView {
-    
+    private let myDevice: UIScreen.DeviceSize = UIScreen.getDevice()
+
     override func draw(_ rect: CGRect) {
         let context = UIGraphicsGetCurrentContext()
         guard let context = context else { return }
         context.saveGState()
-        context.setLineWidth(1)
+        context.setLineWidth(myDevice.stickerBorderWidth)
         let dash: [CGFloat] = [1.0, 0.0]
         context.setLineDash(phase: 0.0, lengths: dash)
         context.setStrokeColor(UIColor.black.cgColor)

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerContollerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerContollerView.swift
@@ -10,14 +10,14 @@ import UIKit
 
 /// 스티커에 붙어있는 버튼  ex) 이동, 삭제 버튼
 class StickerControllerView: UIImageView {
-    private let controlSize = CGSize(width: 22, height: 22)
+    private let myDevice: UIScreen.DeviceSize = UIScreen.getDevice()
     
     init(image: UIImage?, gestureRecognizer: UIGestureRecognizer) {
         super.init(image: image)
 
         self.tintColor = .black
         self.addGestureRecognizer(gestureRecognizer)
-        self.frame = CGRect(origin: .zero, size: controlSize)
+        self.frame = CGRect(origin: .zero, size: myDevice.stickerControllerSize)
 
         layer.cornerRadius = frame.width / 2
         isUserInteractionEnabled = true

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerContollerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerContollerView.swift
@@ -1,0 +1,30 @@
+//
+//  StickerContollerView.swift
+//  MacC-GoldenRatio
+//
+//  Created by 김상현 on 2022/10/01.
+//
+
+import UIKit
+
+
+/// 스티커에 붙어있는 버튼  ex) 이동, 삭제 버튼
+class StickerControllerView: UIImageView {
+    private let controlSize = CGSize(width: 22, height: 22)
+    
+    init(image: UIImage?, gestureRecognizer: UIGestureRecognizer) {
+        super.init(image: image)
+
+        self.tintColor = .black
+        self.addGestureRecognizer(gestureRecognizer)
+        self.frame = CGRect(origin: .zero, size: controlSize)
+
+        layer.cornerRadius = frame.width / 2
+        isUserInteractionEnabled = true
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerView.swift
@@ -1,0 +1,296 @@
+//
+//  StickerView.swift
+//  MacC-GoldenRatio
+//
+//  Created by 김상현 on 2022/10/01.
+//
+
+import UIKit
+
+class StickerView: UIView {
+    private var touchStart: CGPoint?
+    private var previousPoint: CGPoint?
+    private var deltaAngle: CGFloat?
+
+    private var resizingController: StickerControllerView!
+    private var deleteController: StickerControllerView!
+    private var borderView: StickerBorderView!
+
+    private var oldBounds: CGRect!
+    private var oldTransform: CGAffineTransform!
+
+    var subviewIsHidden = false {
+        willSet {
+            self.subviews.forEach{
+                if $0 is StickerControllerView || $0 is StickerBorderView {
+                    $0.isHidden = newValue
+                }
+            }
+        }
+    }
+    
+    init(image: UIImage, size: CGSize) {
+        let stickerImageView = UIImageView(image: image)
+        stickerImageView.contentMode = .scaleAspectFit
+        stickerImageView.frame = CGRect(origin: .zero, size: size)
+        super.init(frame: stickerImageView.frame)
+
+        DispatchQueue.main.async {
+            self.setupContentView(content: stickerImageView)
+            self.setupDefaultAttributes()
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        DispatchQueue.main.async {
+            self.setupDefaultAttributes()
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        DispatchQueue.main.async {
+            self.setupDefaultAttributes()
+        }
+    }
+
+    func switchControls(toState state: Bool, animated: Bool = false) {
+        if animated {
+            let controlAlpha: CGFloat = state ? 1 : 0
+            UIView.animate(withDuration: 0.3, animations: {
+                self.resizingController.alpha = controlAlpha
+                self.deleteController.alpha = controlAlpha
+                self.borderView.alpha = controlAlpha
+            })
+        } else {
+            resizingController.isHidden = !state
+            deleteController.isHidden = !state
+            borderView.isHidden = !state
+        }
+    }
+
+    private func setupDefaultAttributes() {
+        let stickerSingleTap = UITapGestureRecognizer(target: self, action: #selector(stickerViewSingleTap(_:)))
+        addGestureRecognizer(stickerSingleTap)
+        
+        borderView = StickerBorderView(frame: bounds)
+        addSubview(borderView)
+        
+        let deleteControlImage = UIImage(systemName: "xmark.circle.fill")
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(singleTap(_:)))
+        deleteController = StickerControllerView(image: deleteControlImage, gestureRecognizer: singleTap)
+        addSubview(deleteController)
+
+        let resizingControlImage = UIImage(systemName: "arrow.clockwise")
+        let panResizeGesture = UIPanGestureRecognizer(target: self, action: #selector(resizeTranslate(_:)))
+        resizingController = StickerControllerView(image: resizingControlImage, gestureRecognizer: panResizeGesture)
+        addSubview(resizingController)
+
+        let pinchResizeGesture = UIPinchGestureRecognizer(target: self, action: #selector(pinch(_:)))
+        pinchResizeGesture.delegate = self
+        addGestureRecognizer(pinchResizeGesture)
+
+        let rotateResizeGesture = UIRotationGestureRecognizer(target: self, action: #selector(rotate(_:)))
+        rotateResizeGesture.delegate = self
+        addGestureRecognizer(rotateResizeGesture)
+
+        updateControlsPosition()
+
+        deltaAngle = atan2(frame.origin.y + frame.height - center.y, frame.origin.x + frame.width - center.x)
+    }
+
+    private func setupContentView(content: UIView) {
+        let contentView = UIView(frame: content.frame)
+        contentView.backgroundColor = .clear
+        contentView.addSubview(content)
+        contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        addSubview(contentView)
+
+        for subview in contentView.subviews {
+            subview.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
+            subview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        }
+    }
+    
+    // MARK: control버튼 제스처 관련 메서드
+    @objc private func singleTap(_ sender: UIPanGestureRecognizer) {
+        let close = sender.view
+        if let close = close {
+            close.superview?.removeFromSuperview()
+        }
+    }
+
+    @objc private func resizeTranslate(_ sender: UIPanGestureRecognizer) {
+        if sender.state == .began {
+            enableTranslucency(state: true)
+            previousPoint = sender.location(in: self)
+            setNeedsDisplay()
+
+        } else if sender.state == .changed {
+            resizeView(recognizer: sender)
+            rotateView(with: deltaAngle, recognizer: sender)
+
+        } else if sender.state == .ended {
+            enableTranslucency(state: false)
+            previousPoint = sender.location(in: self)
+            setNeedsDisplay()
+        }
+        updateControlsPosition()
+    }
+
+    private func resizeView(recognizer: UIPanGestureRecognizer) {
+        let point = recognizer.location(in: self)
+        guard let previousPoint = previousPoint else {
+            return
+        }
+        let diagonal = sqrt(pow(point.x, 2) + pow(point.y, 2))
+        let previousDiagonal = sqrt(pow(previousPoint.x, 2) + pow(previousPoint.y, 2))
+        let totalRatio = pow(diagonal / previousDiagonal, 2)
+
+        bounds = CGRect(x: 0, y: 0, width: bounds.size.width * totalRatio, height: bounds.size.height * totalRatio)
+        self.previousPoint = recognizer.location(in: self)
+    }
+
+    private func rotateView(with deltaAngle: CGFloat?, recognizer: UIPanGestureRecognizer) {
+        let angle = atan2(recognizer.location(in: superview).y - center.y,
+                          recognizer.location(in: superview).x - center.x)
+
+        if let deltaAngle = deltaAngle {
+            let angleDiff = deltaAngle - angle
+            transform = CGAffineTransformMakeRotation(-angleDiff)
+        }
+    }
+
+    private func updateControlsPosition() {
+        let offset = 5.0
+        borderView.frame = CGRect(x: -offset, y: -offset, width: bounds.size.width + offset * 2,
+                                  height: bounds.size.height + offset * 2)
+
+        deleteController.center = CGPoint(x: borderView.frame.maxX, y: borderView.frame.origin.y)
+        resizingController.center = CGPoint(x: borderView.frame.maxX, y: borderView.frame.maxY)
+    }
+
+    // MARK: 스티커 자체에 입력되는 제스처 관련 메서드
+    @objc private func stickerViewSingleTap(_ sender: UITapGestureRecognizer) {
+        if subviewIsHidden == true {
+            self.subviewIsHidden.toggle()
+        }
+    }
+    
+    @objc private func pinch(_ sender: UIPinchGestureRecognizer) {
+        guard subviewIsHidden == false else { return }
+        
+        if sender.state == .began {
+            oldBounds = bounds
+            enableTranslucency(state: true)
+            previousPoint = sender.location(in: self)
+            setNeedsDisplay()
+        } else if sender.state == .changed {
+            bounds = CGRect(x: 0, y: 0, width: oldBounds.width * sender.scale,
+                            height: oldBounds.height * sender.scale)
+        } else if sender.state == .ended {
+            oldBounds = bounds
+            enableTranslucency(state: false)
+            previousPoint = sender.location(in: self)
+            setNeedsDisplay()
+        }
+        updateControlsPosition()
+    }
+
+    @objc private func rotate(_ sender: UIRotationGestureRecognizer) {
+        guard subviewIsHidden == false else { return }
+
+        if sender.state == .began {
+            oldTransform = transform
+            enableTranslucency(state: true)
+            previousPoint = sender.location(in: self)
+            setNeedsDisplay()
+        } else if sender.state == .changed {
+            transform = CGAffineTransformRotate(oldTransform, sender.rotation)
+        } else if sender.state == .ended {
+            oldTransform = transform
+            enableTranslucency(state: false)
+            previousPoint = sender.location(in: self)
+            setNeedsDisplay()
+        }
+        updateControlsPosition()
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard subviewIsHidden == false else { return }
+        
+        enableTranslucency(state: true)
+
+        let touch = touches.first
+        if let touch = touch {
+            touchStart = touch.location(in: superview)
+        }
+    }
+    
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard subviewIsHidden == false else { return }
+
+        let touchLocation = touches.first?.location(in: self)
+        if resizingController.frame.contains(touchLocation!) {
+            return
+        }
+
+        guard let touch = touches.first?.location(in: superview) else { return }
+        translateUsingTouchLocation(touchPoint: touch)
+        touchStart = touch
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard subviewIsHidden == false else { return }
+
+        enableTranslucency(state: false)
+    }
+
+    private func translateUsingTouchLocation(touchPoint: CGPoint) {
+        if let touchStart = touchStart {
+            center = CGPoint(x: center.x + touchPoint.x - touchStart.x, y: center.y + touchPoint.y - touchStart.y)
+        }
+    }
+
+    private func enableTranslucency(state: Bool) {
+        superview?.bringSubviewToFront(self)
+        
+        UIView.animate(withDuration: 0.1) {
+            if state == true {
+                self.alpha = 0.65
+            } else {
+                self.alpha = 1
+            }
+        }
+    }
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if resizingController.frame.contains(point) || deleteController.frame.contains(point) || bounds.contains(point) {
+
+            for subview in subviews.reversed() {
+                let convertedPoint = subview.convert(point, from: self)
+                let hitTestView = subview.hitTest(convertedPoint, with: event)
+                if hitTestView != nil {
+                    return hitTestView
+                }
+            }
+            return self
+        }
+        return nil
+    }
+}
+
+extension StickerView: UIGestureRecognizerDelegate {
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer is (UIPinchGestureRecognizer) &&
+            otherGestureRecognizer is (UIRotationGestureRecognizer) {
+            return true
+        } else {
+            return false
+        }
+    }
+
+}

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class StickerView: UIView {
+    private let pageViewModel = PageViewModel.pageViewModel
     private let myDevice: UIScreen.DeviceSize = UIScreen.getDevice()
     
     private var touchStart: CGPoint?
@@ -122,6 +123,7 @@ class StickerView: UIView {
         let close = sender.view
         if let close = close {
             close.superview?.removeFromSuperview()
+            pageViewModel.removeSticker(self)
         }
     }
 
@@ -224,6 +226,8 @@ class StickerView: UIView {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard subviewIsHidden == false else { return }
         
+        superview?.bringSubviewToFront(self)
+        pageViewModel.bringStickerToFront(self)
         enableTranslucency(state: true)
 
         let touch = touches.first
@@ -258,8 +262,6 @@ class StickerView: UIView {
     }
 
     private func enableTranslucency(state: Bool) {
-        superview?.bringSubviewToFront(self)
-        
         UIView.animate(withDuration: 0.1) {
             if state == true {
                 self.alpha = 0.65

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Views/Sticker/StickerView.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class StickerView: UIView {
+    private let myDevice: UIScreen.DeviceSize = UIScreen.getDevice()
+    
     private var touchStart: CGPoint?
     private var previousPoint: CGPoint?
     private var deltaAngle: CGFloat?
@@ -165,9 +167,9 @@ class StickerView: UIView {
     }
 
     private func updateControlsPosition() {
-        let offset = 5.0
-        borderView.frame = CGRect(x: -offset, y: -offset, width: bounds.size.width + offset * 2,
-                                  height: bounds.size.height + offset * 2)
+        let inset = myDevice.stickerBorderInset
+        borderView.frame = CGRect(x: -inset, y: -inset, width: bounds.size.width + inset * 2,
+                                  height: bounds.size.height + inset * 2)
 
         deleteController.center = CGPoint(x: borderView.frame.maxX, y: borderView.frame.origin.y)
         resizingController.center = CGPoint(x: borderView.frame.maxX, y: borderView.frame.maxY)


### PR DESCRIPTION
## 작업사항
- 글 작성 페이지 UI
- 글 작성 페이지 안에 스티커(사진) 넣기 기능 구현

<br>

## ScreenShot
<img src="https://user-images.githubusercontent.com/74828662/193450219-9986671c-ac3f-4730-9680-ab5ca08b59e4.PNG" width="180" height="400"/> <img src="https://user-images.githubusercontent.com/74828662/193450220-1ba4ccfa-888d-4b50-9438-fecf052ed826.PNG" width="180" height="400"/> <img src="https://user-images.githubusercontent.com/74828662/193450221-3ca66d99-15a0-4bc2-b273-12e9ebadf98c.PNG" width="180" height="400"/> <img src="https://user-images.githubusercontent.com/74828662/193450225-f2b0f62a-6830-4452-b7d4-7d4feb94d9f1.PNG" width="180" height="400"/>

<br>

## To Reviewers
- 파베 연동, 페이지 보기 기능 구현은 다음 풀리퀘에 넣겠습니다.