### PR TITLE
Feat/10&11&36 썸네일 이미지, 캘린더 뷰, 다이어리 편집 화면 수정

### DIFF
--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Cells/DiaryConfigCollectionViewCell.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Cells/DiaryConfigCollectionViewCell.swift
@@ -44,10 +44,9 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
         return button
     }()
     
-    private lazy var clearButton: UIButton = {
+    lazy var clearButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
-        button.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
         button.tintColor = .systemGray
         return button
     }()
@@ -70,8 +69,7 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
             
             switch contentType {
             case .diaryName:
-                // contentTextField?.text = diary.diaryName
-                contentButton.setTitle(diary.diaryName, for: .normal)
+                contentButton.setTitle(nil, for: .normal)
             case .location:
                 contentButton.setTitle(diary.diaryLocation.locationName, for: .normal)
             case .diaryDate:
@@ -81,8 +79,15 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
                 contentButton.setTitle("PlaceHolder", for: .normal)
             }
         } else {
-            contentButton.tintColor = .placeholderText
-            contentButton.setTitle("PlaceHolder", for: .normal)
+            switch contentType {
+            case .diaryName:
+                contentButton.setTitle(nil, for: .normal)
+            case .location, .diaryDate:
+                contentButton.tintColor = .placeholderText
+                contentButton.setTitle("PlaceHolder", for: .normal)
+            default:
+                contentButton.setTitle(nil, for: .normal)
+            }
         }
     }
     
@@ -91,7 +96,7 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
         
         contentView.backgroundColor = .clear
         
-        [contentTitle, clearButton, dividerView, contentButton].forEach {
+        [contentTitle, contentButton, dividerView, clearButton].forEach {
             contentView.addSubview($0)
         }
         
@@ -117,14 +122,6 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
             $0.trailing.equalToSuperview().inset(50)
             $0.height.equalTo(44)
             $0.bottom.equalToSuperview()
-        }
-    }
-    
-    @objc func clearButtonTapped() {
-        UIView.performWithoutAnimation {
-            // contentTextField?.text = nil
-            contentButton.setTitle("PlaceHolder", for: .normal)
-            contentButton.tintColor = .placeholderText
         }
     }
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Cells/DiaryConfigCollectionViewCell.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Cells/DiaryConfigCollectionViewCell.swift
@@ -36,22 +36,14 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
         title.font = device.diaryConfigCellTitleFont
         return title
     }()
-
-    lazy var contentTextField: UITextField? = {
-        let textField = UITextField()
-        textField.placeholder = "PlaceHolder"
-        textField.font = UIFont(name: "EF_Diary", size: 17)
-        textField.returnKeyType = .done
-        textField.delegate = self
-        return textField
-    }()
     
-    lazy var contentButton: UIButton? = {
+    lazy var contentButton: UIButton = {
         let button = UIButton(type: .system)
         button.titleLabel?.font = device.diaryConfigCellContentFont
+        button.contentHorizontalAlignment = .left
         return button
     }()
-
+    
     private lazy var clearButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
@@ -65,7 +57,7 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
         view.backgroundColor = UIColor.placeholderText
         return view
     }()
-
+    
     // CollectionView에서 Cell초기화 담당
     func setContent(indexPath: IndexPath, diary: Diary?) {
         contentType = ConfigContentType.allCases[indexPath.row]
@@ -74,23 +66,23 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
         if let diary = diary {
             let startDate = diary.diaryStartDate.toDate() ?? Date()
             let endDate = diary.diaryEndDate.toDate() ?? Date()
-            contentButton?.tintColor = .black
+            contentButton.tintColor = .black
             
             switch contentType {
             case .diaryName:
                 // contentTextField?.text = diary.diaryName
-                contentButton?.setTitle(diary.diaryName, for: .normal)
+                contentButton.setTitle(diary.diaryName, for: .normal)
             case .location:
-                contentButton?.setTitle(diary.diaryLocation.locationName, for: .normal)
+                contentButton.setTitle(diary.diaryLocation.locationName, for: .normal)
             case .diaryDate:
-                contentButton?.setTitle("\(startDate.customFormat()) \(startDate.dayOfTheWeek())  - \(endDate.customFormat()) \(endDate.dayOfTheWeek())", for: .normal)
+                contentButton.setTitle("\(startDate.customFormat()) \(startDate.dayOfTheWeek())  - \(endDate.customFormat()) \(endDate.dayOfTheWeek())", for: .normal)
             default:
-                contentButton?.tintColor = .placeholderText
-                contentButton?.setTitle("PlaceHolder", for: .normal)
+                contentButton.tintColor = .placeholderText
+                contentButton.setTitle("PlaceHolder", for: .normal)
             }
         } else {
-            contentButton?.tintColor = .placeholderText
-            contentButton?.setTitle("PlaceHolder", for: .normal)
+            contentButton.tintColor = .placeholderText
+            contentButton.setTitle("PlaceHolder", for: .normal)
         }
     }
     
@@ -99,10 +91,10 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
         
         contentView.backgroundColor = .clear
         
-        [contentTitle, clearButton, dividerView].forEach {
+        [contentTitle, clearButton, dividerView, contentButton].forEach {
             contentView.addSubview($0)
         }
-
+        
         contentTitle.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(device.diaryConfigCellLeftInset)
             $0.top.equalToSuperview().inset(device.diaryConfigCellTopInset)
@@ -120,37 +112,19 @@ class DiaryConfigCollectionViewCell: UICollectionViewCell {
             $0.height.equalTo(1)
         }
         
-        switch contentType {
-        case .diaryName:
-            contentView.addSubview(contentButton ?? UIButton())
-            contentButton?.snp.makeConstraints{
-                $0.leading.equalTo(contentTitle)
-                $0.height.equalTo(44)
-                $0.bottom.equalToSuperview()
-            }
-        case .diaryDate, .location:
-            contentView.addSubview(contentButton ?? UIButton())
-            contentButton?.snp.makeConstraints{
-                $0.leading.equalTo(contentTitle)
-                $0.height.equalTo(44)
-                $0.bottom.equalToSuperview()
-            }
-        case .none:
-            print("Ther will be no Content Type")
+        contentButton.snp.makeConstraints{
+            $0.leading.equalTo(contentTitle)
+            $0.trailing.equalToSuperview().inset(50)
+            $0.height.equalTo(44)
+            $0.bottom.equalToSuperview()
         }
     }
     
     @objc func clearButtonTapped() {
         UIView.performWithoutAnimation {
-            contentTextField?.text = nil
-            contentButton?.setTitle("PlaceHolder", for: .normal)
-            contentButton?.tintColor = .placeholderText
+            // contentTextField?.text = nil
+            contentButton.setTitle("PlaceHolder", for: .normal)
+            contentButton.tintColor = .placeholderText
         }
-    }
-}
-
-extension DiaryConfigCollectionViewCell: UITextFieldDelegate {
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.endEditing(true)
     }
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/Date+.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/Date+.swift
@@ -20,4 +20,16 @@ extension Date {
 
         return weekdays[Calendar.current.component(.weekday, from: self) - 1]
     }
+    
+    static func dates(from fromDate: Date, to toDate: Date) -> [Date] {
+        var dates: [Date] = []
+        var date = fromDate
+        
+        while date <= toDate {
+            dates.append(date)
+            guard let newDate = Calendar.current.date(byAdding: .day, value: 1, to: date) else { break }
+            date = newDate
+        }
+        return dates
+    }
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/UIScreen+.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/UIScreen+.swift
@@ -431,7 +431,12 @@ extension UIScreen {
         }
         
 // MARK: - My Diary Pages
-        
+// MARK: - PopUp Modal View
+        var popUpModalFont: UIFont {
+            switch self {
+            default: return UIFont(name: "EF_Diary", size: 17) ?? UIFont.systemFont(ofSize: 17)
+            }
+        }
 	}
 
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarDateCollectionViewCell.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarDateCollectionViewCell.swift
@@ -12,7 +12,13 @@ class CalendarDateCollectionViewCell: UICollectionViewCell {
     lazy var selectionBackgroundView: UIView = {
         let view = UIView()
         view.clipsToBounds = true
-        view.backgroundColor = .blue
+        view.backgroundColor = UIColor(red: 0.608, green: 0.533, blue: 0.486, alpha: 1.0)
+        return view
+    }()
+    
+    lazy var termBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 0.945, green: 0.914, blue: 0.875, alpha: 0.4)
         return view
     }()
     
@@ -20,7 +26,7 @@ class CalendarDateCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         label.textAlignment = .center
         label.font = UIFont.systemFont(ofSize: 20, weight: .regular)
-        label.textColor = .label
+        label.textColor = UIColor(red: 0.816, green: 0.765, blue: 0.702, alpha: 1.0)
         return label
     }()
     
@@ -49,7 +55,7 @@ class CalendarDateCollectionViewCell: UICollectionViewCell {
         isAccessibilityElement = true
         accessibilityTraits = .button
         
-        [selectionBackgroundView, numberLabel].forEach {
+        [selectionBackgroundView, termBackgroundView, numberLabel].forEach {
             contentView.addSubview($0)
         }
     }
@@ -74,6 +80,12 @@ class CalendarDateCollectionViewCell: UICollectionViewCell {
             $0.size.equalTo(CGSize(width: size, height: size))
         }
         
+        termBackgroundView.snp.makeConstraints {
+            $0.center.equalTo(numberLabel)
+            $0.width.equalTo(contentView.snp.width)
+            $0.height.equalTo(size)
+        }
+        
         selectionBackgroundView.layer.cornerRadius = size / 2
     }
     
@@ -94,6 +106,10 @@ extension CalendarDateCollectionViewCell {
         } else {
             applyDefaultStyle(isWithinDisplayedMonth: day.isWithinDisplayedMonth)
         }
+        
+        if day.isInTerm {
+            applyInTermStyle()
+        }
     }
 
     var isSmallScreenSize: Bool {
@@ -112,12 +128,20 @@ extension CalendarDateCollectionViewCell {
         selectionBackgroundView.isHidden = isSmallScreenSize
     }
     
+    func applyInTermStyle() {
+        accessibilityTraits.insert(.selected)
+        accessibilityHint = nil
+        
+        termBackgroundView.isHidden = isSmallScreenSize
+    }
+    
     func applyDefaultStyle(isWithinDisplayedMonth: Bool) {
         accessibilityTraits.remove(.selected)
         accessibilityHint = "Tap to select"
         
-        numberLabel.textColor = isWithinDisplayedMonth ? .label : .secondaryLabel
+        numberLabel.textColor = isWithinDisplayedMonth ? .label : UIColor(red: 0.816, green: 0.765, blue: 0.702, alpha: 1.0)
         selectionBackgroundView.isHidden = true
+        termBackgroundView.isHidden = true
     }
 }
 

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarDateCollectionViewCell.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarDateCollectionViewCell.swift
@@ -9,22 +9,22 @@ import SnapKit
 import UIKit
 
 class CalendarDateCollectionViewCell: UICollectionViewCell {
-    private lazy var selectionBackgroundView: UIView = {
+    lazy var selectionBackgroundView: UIView = {
         let view = UIView()
         view.clipsToBounds = true
-        view.backgroundColor = .systemRed
+        view.backgroundColor = .blue
         return view
     }()
     
-    private lazy var numberLabel: UILabel = {
+    lazy var numberLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
-        label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
+        label.font = UIFont.systemFont(ofSize: 20, weight: .regular)
         label.textColor = .label
         return label
     }()
     
-    private lazy var accessibilityDateFormatter: DateFormatter = {
+    lazy var accessibilityDateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.calendar = Calendar(identifier: .gregorian)
         dateFormatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM d")
@@ -85,7 +85,7 @@ class CalendarDateCollectionViewCell: UICollectionViewCell {
 }
 
 // MARK: - Appearance
-private extension CalendarDateCollectionViewCell {
+extension CalendarDateCollectionViewCell {
     func updateSelectionStatus() {
         guard let day = day else { return }
         

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerFooterView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerFooterView.swift
@@ -8,6 +8,7 @@ import SnapKit
 import UIKit
 
 class CalendarPickerFooterView: UIView {
+    private var timeInterval: [Date] = []
     var buttonLabel: String = "날짜를 선택하세요" {
         didSet {
             self.selectButton.setTitle(buttonLabel, for: .normal)
@@ -16,7 +17,8 @@ class CalendarPickerFooterView: UIView {
     
     private lazy var selectButton: UIButton = {
         let button = UIButton()
-        button.setTitle("날짜를 선택하세요", for: .normal)
+        button.setTitle(buttonLabel, for: .normal)
+        button.titleLabel?.font = UIFont(name: "EF_Diary", size: 14) ?? UIFont.systemFont(ofSize: 14)
         button.backgroundColor = .systemGray
         button.layer.cornerRadius = 5
         button.addTarget(self, action: #selector(selectButtonTapped), for: .touchUpInside)
@@ -25,8 +27,17 @@ class CalendarPickerFooterView: UIView {
     
     let selectButtonCompletionHanlder: (() -> Void)
     
-    init(selectButtonCompletionHanlder: @escaping (() -> Void)) {
+    init(timeInterval: [Date], selectButtonCompletionHanlder: @escaping (() -> Void)) {
+        self.timeInterval = timeInterval
         self.selectButtonCompletionHanlder = selectButtonCompletionHanlder
+        
+        if timeInterval.isEmpty {
+            self.buttonLabel = "날짜를 선택하세요"
+        } else {
+            let startDate = timeInterval[0]
+            let endDate = timeInterval[1]
+            self.buttonLabel = "\(startDate.customFormat()) \(startDate.dayOfTheWeek())  - \(endDate.customFormat()) \(endDate.dayOfTheWeek())"
+        }
         
         super.init(frame: CGRect.zero)
         
@@ -54,8 +65,8 @@ class CalendarPickerFooterView: UIView {
         selectButton.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(16)
             $0.trailing.equalToSuperview().inset(16)
-            $0.center.equalToSuperview()
-            $0.height.equalToSuperview().multipliedBy(0.65)
+            $0.bottom.equalToSuperview().inset(12)
+            $0.height.equalTo(40)
         }
     }
     

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerFooterView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerFooterView.swift
@@ -15,11 +15,11 @@ class CalendarPickerFooterView: UIView {
         }
     }
     
-    private lazy var selectButton: UIButton = {
+    lazy var selectButton: UIButton = {
         let button = UIButton()
         button.setTitle(buttonLabel, for: .normal)
         button.titleLabel?.font = UIFont(name: "EF_Diary", size: 14) ?? UIFont.systemFont(ofSize: 14)
-        button.backgroundColor = .systemGray
+        button.backgroundColor = UIColor(red: 0.608, green: 0.533, blue: 0.486, alpha: 1.0)
         button.layer.cornerRadius = 5
         button.addTarget(self, action: #selector(selectButtonTapped), for: .touchUpInside)
         return button

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerHeaderView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerHeaderView.swift
@@ -11,7 +11,7 @@ import UIKit
 class CalendarPickerHeaderView: UIView {
     lazy var monthLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 26, weight: .bold)
+        label.font = .systemFont(ofSize: 20, weight: .bold)
         label.text = "Month"
         label.accessibilityTraits = .header
         label.isAccessibilityElement = true
@@ -121,25 +121,24 @@ class CalendarPickerHeaderView: UIView {
         super.layoutSubviews()
         
         monthLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(15)
-            $0.leading.equalToSuperview().inset(15)
+            $0.top.equalToSuperview().inset(16)
+            $0.leading.equalToSuperview().inset(16)
         }
         
         previousMonthButton.snp.makeConstraints {
             $0.centerY.equalTo(monthLabel)
-            $0.trailing.equalTo(nextMonthButton.snp.leading).offset(-20)
+            $0.trailing.equalTo(nextMonthButton.snp.leading).offset(-16)
         }
         
         nextMonthButton.snp.makeConstraints {
             $0.centerY.equalTo(monthLabel)
             $0.size.equalTo(CGSize(width: 28, height: 28))
-            $0.trailing.equalToSuperview().inset(15)
+            $0.trailing.equalToSuperview().inset(16)
         }
         
         dayOfWeekStackView.snp.makeConstraints {
-            $0.leading.equalToSuperview()
-            $0.trailing.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(5)
+            $0.leading.trailing.equalToSuperview().inset(6)
+            $0.bottom.equalToSuperview().inset(10)
         }
     }
     

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerHeaderView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerHeaderView.swift
@@ -15,6 +15,7 @@ class CalendarPickerHeaderView: UIView {
         label.text = "Month"
         label.accessibilityTraits = .header
         label.isAccessibilityElement = true
+        label.textColor = UIColor(red: 0.608, green: 0.533, blue: 0.486, alpha: 1.0)
         return label
     }()
     
@@ -22,7 +23,7 @@ class CalendarPickerHeaderView: UIView {
         let button = UIButton()
         
         button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
-        button.tintColor = .black
+        button.tintColor = UIColor(red: 0.608, green: 0.533, blue: 0.486, alpha: 1.0)
         
         button.addTarget(self, action: #selector(didTapPreviousMonthButton), for: .touchUpInside)
         return button
@@ -32,7 +33,7 @@ class CalendarPickerHeaderView: UIView {
         let button = UIButton()
         
         button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
-        button.tintColor = .black
+        button.tintColor = UIColor(red: 0.608, green: 0.533, blue: 0.486, alpha: 1.0)
         
         button.addTarget(self, action: #selector(didTapNextMonthButton), for: .touchUpInside)
         return button

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarPickerViewController.swift
@@ -9,7 +9,7 @@ import SnapKit
 import UIKit
 
 class CalendarPickerViewController: UIViewController {
-    var dateInterval: [Date] = []
+    var dateInterval: [Date]
     
     // MARK: Views
     private lazy var dimmedBackgroundView: UIView = {
@@ -20,7 +20,7 @@ class CalendarPickerViewController: UIViewController {
         return view
     }()
     
-    private lazy var collectionView: UICollectionView = {
+    lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.minimumLineSpacing = 0
         layout.minimumInteritemSpacing = 0
@@ -42,24 +42,29 @@ class CalendarPickerViewController: UIViewController {
             self.startBaseDate = self.calendar.date(byAdding: .month, value: 1, to: self.startBaseDate) ?? self.startBaseDate
         })
     
-    lazy var footerView = CalendarPickerFooterView(
-        selectButtonCompletionHanlder: { [weak self] in
+    lazy var footerView = CalendarPickerFooterView(timeInterval: dateInterval, selectButtonCompletionHanlder: { [weak self] in
             guard let self = self else { return }
-            
             
             self.selectedDateChanged(self.dateInterval)
             self.dismissCalendar()
         })
     
+    private lazy var closeButton: UIButton = {
+       let button = UIButton()
+        button.setImage(UIImage(named: "plusButton"), for: .normal) // TODO: 이미지 수정 필요
+        button.addTarget(self, action: #selector(dismissCalendar), for: .touchUpInside)
+        return button
+    }()
+    
     // MARK: Calendar Data Values
     
     private let selectedStartDate: Date
+    
     private var startBaseDate: Date {
         didSet {
             days = generateDaysInMonth(for: startBaseDate)
             collectionView.reloadData()
             headerView.baseDate = startBaseDate
-            
         }
     }
     private var endBaseDate: Date? {
@@ -86,11 +91,18 @@ class CalendarPickerViewController: UIViewController {
     
     // MARK: Initializers
     
-    init(startBaseDate: Date, selectedDateChanged: @escaping (([Date]) -> Void)) {
-        self.selectedStartDate = startBaseDate
-        self.startBaseDate = startBaseDate
-        self.selectedDateChanged = selectedDateChanged
+    init(dateArray: [Date], selectedDateChanged: @escaping (([Date]) -> Void)) {
+        self.dateInterval = dateArray
         
+        if dateArray.isEmpty {
+            self.selectedStartDate = Date()
+            self.startBaseDate = Date()
+        } else {
+            self.selectedStartDate = dateArray[0]
+            self.startBaseDate = dateArray[0]
+        }
+        self.selectedDateChanged = selectedDateChanged
+
         super.init(nibName: nil, bundle: nil)
         
         modalPresentationStyle = .overCurrentContext
@@ -108,7 +120,7 @@ class CalendarPickerViewController: UIViewController {
         super.viewDidLoad()
         collectionView.backgroundColor = .systemGroupedBackground
         
-        [dimmedBackgroundView, collectionView, headerView, footerView].forEach {
+        [dimmedBackgroundView, collectionView, headerView, footerView, closeButton].forEach {
             view.addSubview($0)
         }
         
@@ -117,7 +129,7 @@ class CalendarPickerViewController: UIViewController {
         }
         
         collectionView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(21)
             $0.centerY.equalToSuperview()
             $0.height.equalToSuperview().multipliedBy(0.35)
         }
@@ -131,13 +143,20 @@ class CalendarPickerViewController: UIViewController {
         footerView.snp.makeConstraints {
             $0.leading.trailing.equalTo(collectionView)
             $0.top.equalTo(collectionView.snp.bottom)
-            $0.height.equalTo(55)
+            $0.height.equalTo(45)
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.top.equalTo(footerView.snp.bottom).offset(30)
+            $0.centerX.equalToSuperview()
+            $0.size.equalTo(CGSize(width: 50, height: 50))
         }
         
         collectionView.register(CalendarDateCollectionViewCell.self, forCellWithReuseIdentifier: CalendarDateCollectionViewCell.reuseIdentifier)
         
         collectionView.dataSource = self
         collectionView.delegate = self
+        
         headerView.baseDate = startBaseDate
     }
     
@@ -147,7 +166,13 @@ class CalendarPickerViewController: UIViewController {
     }
     
     @objc private func dismissCalendar() {
-        self.dismiss(animated: true, completion: nil)
+        if dateInterval.count == 2 {
+            self.dismiss(animated: true, completion: nil)
+        } else {
+            print("날짜를 2개 고르세요")
+            // TODO: Toast View
+        }
+        
     }
 }
 
@@ -191,7 +216,7 @@ private extension CalendarPickerViewController {
     func generateDay(offsetBy dayOffset: Int, for startBaseDate: Date, isWithinDisplayedMonth: Bool) -> Day {
         let date = calendar.date(byAdding: .day, value: dayOffset, to: startBaseDate) ?? startBaseDate
         
-        return Day(date: date, number: dateFormatter.string(from: date), isSelected: calendar.isDate(date, inSameDayAs: selectedStartDate), isWithinDisplayedMonth: isWithinDisplayedMonth)
+        return Day(date: date, number: dateFormatter.string(from: date), isSelected: false, isWithinDisplayedMonth: isWithinDisplayedMonth)
     }
     
     func generateStartOfNextMonth(
@@ -231,6 +256,10 @@ extension CalendarPickerViewController: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarDateCollectionViewCell.reuseIdentifier, for: indexPath) as! CalendarDateCollectionViewCell
         
         cell.day = day
+        guard let date = cell.day?.date else { return cell }
+        if dateInterval.contains(date) {
+            cell.day?.isSelected = true
+        }
         return cell
     }
 }
@@ -240,15 +269,15 @@ extension CalendarPickerViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let day = days[indexPath.row]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarDateCollectionViewCell.reuseIdentifier, for: indexPath) as! CalendarDateCollectionViewCell
-        
         cell.day = day
+        cell.updateSelectionStatus()
         collectionView.reloadData()
         updateFooterButtonLabel(day: day)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = Int(collectionView.frame.width / 7)
-        let height = Int(collectionView.frame.height) / numberOfWeeksInBaseDate
+        let width = Int((collectionView.frame.width) / 7)
+        let height = Int(collectionView.frame.height - 10) / numberOfWeeksInBaseDate
         return CGSize(width: width, height: height)
     }
     

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/Day.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/Day.swift
@@ -10,6 +10,6 @@ import Foundation
 struct Day {
   let date: Date
   let number: String
-  let isSelected: Bool
+  var isSelected: Bool
   let isWithinDisplayedMonth: Bool
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/Day.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/Day.swift
@@ -8,8 +8,9 @@
 import Foundation
 
 struct Day {
-  let date: Date
-  let number: String
-  var isSelected: Bool
-  let isWithinDisplayedMonth: Bool
+    let date: Date
+    let number: String
+    var isSelected: Bool
+    var isInTerm: Bool
+    let isWithinDisplayedMonth: Bool
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/DiaryConfigViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/DiaryConfigViewController.swift
@@ -30,7 +30,7 @@ class DiaryConfigViewController: UIViewController {
     private var configState: ConfigState
     private var viewModel = DiaryConfigViewModel()
     private var diaryToConfig: Diary?
-    
+    private var dateInterval: [Date] = []
     
     init(mode configState: ConfigState, diary: Diary?) {
         self.configState = configState
@@ -238,12 +238,13 @@ extension DiaryConfigViewController: UICollectionViewDataSource {
             self.present(mapSearchViewController, animated: true)
             
         case .diaryDate:
-            let pickerController = CalendarPickerViewController(startBaseDate: Date(), selectedDateChanged: { [self, weak sender] date in
+            let pickerController = CalendarPickerViewController(dateArray: dateInterval, selectedDateChanged: { [self, weak sender] date in
                     guard let sender = sender else { return }
                     UIView.performWithoutAnimation {
                         let startDate = date[0]
                         let endDate = date[1]
                         
+                        dateInterval = [startDate, endDate]
                         self.viewModel.startDate = startDate.customFormat()
                         self.viewModel.endDate = endDate.customFormat()
                         

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/DiaryConfigViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/DiaryConfigViewController.swift
@@ -52,9 +52,15 @@ class DiaryConfigViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // 자연스러운 TextFiled를 위한 gesture
+        let tapGesture = UITapGestureRecognizer(target: view, action: #selector(UIView.endEditing))
+        view.addGestureRecognizer(tapGesture)
+        
         view.backgroundColor = UIColor(patternImage: UIImage(named: "backgroundTexture.png") ?? UIImage())
+        
         titleSetup()
         collectionViewSetup()
+        textFieldSetup()
     }
     
     private lazy var diaryConfigCollectionView: UICollectionView = {
@@ -73,6 +79,7 @@ class DiaryConfigViewController: UIViewController {
     lazy var contentTextField: UITextField = {
         let textField = UITextField()
         textField.placeholder = "PlaceHolder"
+        textField.text = diaryToConfig?.diaryName ?? nil
         textField.font = UIFont(name: "EF_Diary", size: 17)
         textField.returnKeyType = .done
         textField.becomeFirstResponder()
@@ -132,12 +139,10 @@ class DiaryConfigViewController: UIViewController {
                     
                 case .modify:
                     self.viewModel.updateDiary()
-                    
-                    // let MyDiaryPagesVC = MyDiaryPagesViewController(diaryData: self.viewModel.diary!)
-                    
                 }
             }
         } else {
+            // TODO: Toast Message로 수정
             let ac = UIAlertController(title: "입력해 주세요", message: "빈 칸을 채워주세요!", preferredStyle: .alert)
             ac.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
             self.present(ac, animated: true)
@@ -172,8 +177,9 @@ class DiaryConfigViewController: UIViewController {
         view.addSubview(contentTextField)
         contentTextField.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(20)
+            $0.trailing.equalToSuperview().inset(50)
             $0.height.equalTo(44)
-            $0.top.equalTo(diaryConfigCollectionView.snp.top).inset(64)
+            $0.top.equalTo(diaryConfigCollectionView.snp.top).inset(62)
         }
     }
     
@@ -209,7 +215,10 @@ extension DiaryConfigViewController: UICollectionViewDataSource {
         }
         
         cell.contentButton.tag = indexPath.row
+        cell.clearButton.tag = indexPath.row
+        
         cell.contentButton.addTarget(self, action: #selector(contentButtonTapped), for: .touchUpInside)
+        cell.clearButton.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
         return cell
     }
     
@@ -222,6 +231,8 @@ extension DiaryConfigViewController: UICollectionViewDataSource {
             textFieldSetup()
             
         case .location:
+            self.contentTextField.endEditing(true)
+            
             let mapSearchViewController = MapSearchViewController()
             mapSearchViewController.completion = { mapItem in
                 UIView.performWithoutAnimation {
@@ -239,6 +250,8 @@ extension DiaryConfigViewController: UICollectionViewDataSource {
             self.present(mapSearchViewController, animated: true)
             
         case .diaryDate:
+            self.contentTextField.endEditing(true)
+            
             let pickerController = CalendarPickerViewController(dateArray: dateInterval, selectedDateChanged: { [self, weak sender] date in
                     guard let sender = sender else { return }
                     UIView.performWithoutAnimation {
@@ -256,6 +269,23 @@ extension DiaryConfigViewController: UICollectionViewDataSource {
                 })
             
             present(pickerController, animated: true, completion: nil)
+        }
+    }
+    
+    @objc func clearButtonTapped(_ sender: UIButton) {
+        let configContentType = ConfigContentType.allCases[sender.tag]
+        
+        switch configContentType {
+        case .diaryName:
+            self.contentTextField.text = nil
+        case .location, .diaryDate:
+            self.contentTextField.endEditing(true)
+            
+            UIView.performWithoutAnimation {
+                let contentButton = self.diaryConfigCollectionView.viewWithTag(sender.tag) as? UIButton ?? UIButton()
+                contentButton.setTitle("PlaceHolder", for: .normal)
+                contentButton.tintColor = .placeholderText
+            }
         }
     }
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/DiaryConfigViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/DiaryConfigViewController.swift
@@ -197,6 +197,7 @@ extension DiaryConfigViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
         guard let cell = diaryConfigCollectionView.dequeueReusableCell(withReuseIdentifier: "DiaryConfigCollectionViewCell", for: indexPath) as? DiaryConfigCollectionViewCell else { return UICollectionViewCell() }
         
         
@@ -207,8 +208,8 @@ extension DiaryConfigViewController: UICollectionViewDataSource {
             cell.setContent(indexPath: indexPath, diary: diaryToConfig)
         }
         
-        cell.contentButton?.tag = indexPath.row
-        cell.contentButton?.addTarget(self, action: #selector(contentButtonTapped), for: .touchUpInside)
+        cell.contentButton.tag = indexPath.row
+        cell.contentButton.addTarget(self, action: #selector(contentButtonTapped), for: .touchUpInside)
         return cell
     }
     

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/DiaryConfigViewModel.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/DiaryConfigViewModel.swift
@@ -48,6 +48,7 @@ class DiaryConfigViewModel {
     }
     
     func updateDiary() {
+        
         if checkAvailable() {
             guard let diaryUUID = self.diaryUUID, let title = self.title, let location = self.location, let startDate = self.startDate, let endDate = self.endDate, let diaryCover = self.diaryCover, let userUIDs = self.userUIDs else { return print("Upload Error") }
             
@@ -91,7 +92,7 @@ class DiaryConfigViewModel {
         let count: Int
         
         if let startDate = startDate?.toDate(), let endDate = endDate?.toDate() {
-            count = Int((endDate).timeIntervalSince(startDate)) / 86400
+            count = Int((endDate).timeIntervalSince(startDate)) / 86400 + 1
         } else {
             count = 1
         }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Main/MyHomeViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/Main/MyHomeViewController.swift
@@ -128,7 +128,6 @@ extension MyHomeViewController: UICollectionViewDelegate {
 	func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
 		let vc = MyDiaryPagesViewController(diaryData: viewModel.diaryData[indexPath.item])
 		// TODO: 수정 예정
-		self.navigationController?.isNavigationBarHidden = false
 		self.navigationController?.pushViewController(vc, animated: true)
 	}
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryPages/MyDiaryPagesViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryPages/MyDiaryPagesViewController.swift
@@ -38,6 +38,24 @@ class MyDiaryPagesViewController: UIViewController {
 		fatalError("init(coder:) has not been implemented")
 	}
     
+    private lazy var backButton: UIButton = {
+        let button = UIButton()
+        let configuration = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold, scale: .medium)
+        button.tintColor = .black
+        button.setImage(UIImage(systemName: "chevron.left", withConfiguration: configuration), for: .normal)
+        button.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var menuButton: UIButton = {
+        let button = UIButton()
+        let configuration = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold, scale: .medium)
+        button.tintColor = .black
+        button.setImage(UIImage(systemName: "ellipsis", withConfiguration: configuration), for: .normal)
+        button.addTarget(self, action: #selector(menuButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.text = diaryData.diaryName
@@ -94,8 +112,7 @@ class MyDiaryPagesViewController: UIViewController {
         
         super.viewDidLoad()
         view.backgroundColor = UIColor(patternImage: UIImage(named: "backgroundTexture.png") ?? UIImage())
-        
-        navigationBarSetup()
+        self.navigationController?.isNavigationBarHidden = true
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -110,6 +127,7 @@ class MyDiaryPagesViewController: UIViewController {
                 print(error.localizedDescription)
             }
             print(diaryData)
+            
             self.collectionViewSetup()
             self.componentsSetup()
             
@@ -118,6 +136,7 @@ class MyDiaryPagesViewController: UIViewController {
     
     // MARK: - Feature methods
     @objc private func backButtonTapped() {
+        self.navigationController?.isNavigationBarHidden = true
         self.navigationController?.popViewController(animated: true)
     }
     
@@ -179,16 +198,6 @@ class MyDiaryPagesViewController: UIViewController {
     }
     
     // MARK: - Setup methods
-    private func navigationBarSetup() {
-        let configuration = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold, scale: .medium)
-        let menuButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis", withConfiguration: configuration), style: .plain, target: self, action: #selector(menuButtonTapped))
-        
-        navigationItem.hidesBackButton = true
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "chevron.left", withConfiguration: configuration), style: .plain, target: self, action: #selector(backButtonTapped))
-        navigationItem.rightBarButtonItem = menuButton
-        navigationItem.leftBarButtonItem?.tintColor = .black
-        navigationItem.rightBarButtonItem?.tintColor = .black
-    }
     
     private func collectionViewSetup() {
         
@@ -201,7 +210,7 @@ class MyDiaryPagesViewController: UIViewController {
     }
     
     private func componentsSetup() {
-        [titleLabel, dayLabel, previousButton, nextButton].forEach {
+        [titleLabel, dayLabel, backButton, menuButton, previousButton, nextButton].forEach {
             view.addSubview($0)
         }
         
@@ -213,6 +222,16 @@ class MyDiaryPagesViewController: UIViewController {
         dayLabel.snp.makeConstraints {
             $0.leading.equalTo(myPagesCollectionView)
             $0.bottom.equalTo(myPagesCollectionView.snp.top).offset(-30)
+        }
+        
+        backButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(13)
+        }
+        
+        menuButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(13)
         }
         
         previousButton.snp.makeConstraints {

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryPages/MyDiaryPagesViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryPages/MyDiaryPagesViewController.swift
@@ -112,13 +112,13 @@ class MyDiaryPagesViewController: UIViewController {
         
         super.viewDidLoad()
         view.backgroundColor = UIColor(patternImage: UIImage(named: "backgroundTexture.png") ?? UIImage())
-        self.navigationController?.isNavigationBarHidden = true
     }
     
     override func viewWillAppear(_ animated: Bool) {
         // Full Modal dismiss 이후 호출, 업데이트된 다이어리 정보 반영
         super.viewWillAppear(animated)
-        
+        self.navigationController?.isNavigationBarHidden = true
+
         // TODO: - modal completion handler 필요?
         Task {
             do {
@@ -261,7 +261,12 @@ extension MyDiaryPagesViewController: UICollectionViewDataSource {
         
         if diaryData.pageThumbnails[indexPath.row] != "NoURL" {
             // TODO: 이미지 로드 해서 cell에 할당
-            cell.previewImageView.image = UIImage(systemName: "applelogo") ?? UIImage()
+            Task {
+                let imageURL = diaryData.pageThumbnails[indexPath.row]
+                FirebaseStorageManager.downloadImage(urlString: imageURL) { image in
+                    cell.previewImageView.image = image
+                }
+            }
         }
         
         return cell
@@ -279,6 +284,7 @@ extension MyDiaryPagesViewController: UICollectionViewDelegate {
         debugPrint(diaryData)
         print(selectedDay)
         self.navigationController?.pushViewController(pageViewController, animated: false)
+        self.navigationController?.isNavigationBarHidden = false
     }
 
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryPages/MyDiaryPagesViewModel.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryPages/MyDiaryPagesViewModel.swift
@@ -44,8 +44,4 @@ class MyDiaryPagesViewModel {
         }
 
     }
-    
-    func getThumbnailImages() {
-        
-    }
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryPages/PopUpViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryPages/PopUpViewController.swift
@@ -136,7 +136,7 @@ class PopUpViewController: UIViewController {
     public func addButton(buttonTitle: String, action: (() -> Void)? = nil) {
         let button = UIButton()
         button.setTitle(buttonTitle, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 17, weight: .light)
+        button.titleLabel?.font = device.popUpModalFont
         button.setTitleColor(.black, for: .normal)
         button.isUserInteractionEnabled = true
         button.addAction(for: .touchUpInside) { _ in


### PR DESCRIPTION
## 작업사항

- MyDiaryPagesView 의 Navigation Back Button 삭제, 커스텀 버튼으로 수정
- 썸네일 이미지 뷰 구현
- 캘린더 뷰 기간설정 구현(HiFi 일부 적용)

<br>

## Changes

- 캘린더에서 기간 설정을 확인 할 수 있도록 하였습니다.
- 메인화면에서 backbutton이 생기던 문제를 수정했습니다.
- 다이어리 편집 화면에서 컨텐츠가 더 잘 선택되도록 수정했습니다. (버튼 크기 증가)
- 부자연스러운 textfield를 수정했습니다(@iDrogba 제보👍)

<br>

## ScreenShot
|캘린더|썸네일 이미지|
|:--:|:--:|
|![image](https://user-images.githubusercontent.com/45297745/195755548-5d0eb0ad-a2d5-4d1f-b6b7-79c9ddcf5b46.png)|![image](https://user-images.githubusercontent.com/45297745/195755430-f915ae21-055c-4bdb-aa27-a5e4810664f2.png)|


<br>

## To Reviewers
- Issues의 여러 항목들이 함께 작업되어서 리뷰하시는데 불편함이 있으실 것 같습니다..주 작업은 캘린더 부분입니다
- 현재 캘린더의 경우 시작일과 끝나는 날짜를 전달받아 캘린더에 표시합니다.(추후 리팩토링에서 중요하게 고려될 부분?)
- 캘린더의 컬렉션뷰 셀이 가지는 모델 타입인 `Day`는 `isSelected` 프로퍼티와 `isInTerm`  프로퍼티를 가집니다.
- 기존 레퍼런스에서 선택된 단일 날짜를 의미하던 `isSelected`를 해당 코드에서는 시작일과 종료일의 의미로 작성했습니다.
- 기존 레퍼런스의 Day 모델에 `isInTerm` 프로퍼티를 추가하여 시작일과 종료일을 제외한 기간의 의미로 작성했습니다.
- UI 레이아웃 속성이나 컬러 등은 가장 마지막에 리팩토링 하겠습니다 


<br>

## 비고
- 토스트알림 뷰 추가 예정


<br>
