### PR TITLE
[feat] #78 AlbumPhotoView 확대 축소 구현

### DIFF
--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Cells/MyAlbum/MyAlbumPhotoCollectionViewCell.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Cells/MyAlbum/MyAlbumPhotoCollectionViewCell.swift
@@ -9,20 +9,57 @@ import SnapKit
 import UIKit
 
 class MyAlbumPhotoCollectionViewCell: UICollectionViewCell {
-	private let myDevice = UIScreen.getDevice()
+	private lazy var scrollView: UIScrollView = {
+		var scrollView = UIScrollView()
+		scrollView.delegate = self
+		scrollView.zoomScale = 1.0
+		scrollView.minimumZoomScale = 1.0
+		scrollView.maximumZoomScale = 5.0
+		scrollView.bounces = false
+		scrollView.showsVerticalScrollIndicator = false
+		scrollView.showsHorizontalScrollIndicator = false
+		return scrollView
+	}()
+	
 	private lazy var imageView: UIImageView = {
-		let imageView =  UIImageView()
-		
+		let imageView = UIImageView()
+		imageView.contentMode = .scaleAspectFit
 		return imageView
 	}()
 	
+	override func prepareForReuse() {
+		self.scrollView.zoomScale = 1.0
+		self.scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
+	}
+	
 	func setup(image: UIImage) {
-		self.addSubview(imageView)
-		imageView.contentMode = .scaleAspectFit
-		imageView.image = image
-		imageView.snp.makeConstraints {
-			$0.edges.equalToSuperview()
+		self.addSubview(scrollView)
+		scrollView.snp.makeConstraints {
+			$0.top.bottom.equalTo(self.safeAreaLayoutGuide)
+			$0.leading.trailing.equalToSuperview()
 		}
 		
+		scrollView.addSubview(imageView)
+		imageView.image = image
+		imageView.snp.makeConstraints {
+			$0.centerY.equalToSuperview()
+			$0.width.equalToSuperview()
+		}
+	}
+}
+
+extension MyAlbumPhotoCollectionViewCell: UIScrollViewDelegate {
+	func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+		return imageView
+	}
+
+	func scrollViewDidScroll(_ scrollView: UIScrollView) {
+		if scrollView.zoomScale <= 1.0 {
+			scrollView.zoomScale = 1.0
+		}
+
+		if scrollView.zoomScale >= 5.0 {
+			scrollView.zoomScale = 5.0
+		}
 	}
 }


### PR DESCRIPTION
## 작업사항

- 사진 상세보기 화면에서 확대 축소 기능 구현

<br>

## Changes

- MyAlbumPhotoCollectionViewCell

<br>

## ScreenShot
<img src="https://user-images.githubusercontent.com/57060443/197596882-5d65e525-6258-4be9-bdf6-f4b159d7bf76.PNG" width="250" height="541"/><img src="https://user-images.githubusercontent.com/57060443/197597191-90e31f16-0daf-4cfc-9c8d-a604a900ab29.jpeg" width="250" height="541"/>

<br>

## To Reviewers
CollectionView에서 paging을 위한 ScrollView와 Cell에서 확대를 위한 ScrollView가 겹쳐 좌우 맨 끝 부분을 scroll해야 페이징이 됩니다. 개인적으로 Cell의 크기를 통해 조절 할 수 있는 부분이지만 디자인이 변할 요소가 있다고 판단하여 일단 적용하진 않았습니다. 추후 대화를 나눈 후에 수정하겠습니다.


<br>

## 비고



<br>
