### PR TITLE
Feat/#140 UI 수정 [캘린더 년/월 선택, ToastMessage, Segmented Control, 로그인 로딩]

### DIFF
--- a/MacC-GoldenRatio/MacC-GoldenRatio.xcodeproj/project.pbxproj
+++ b/MacC-GoldenRatio/MacC-GoldenRatio.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		CC6C7F23291D2A6300B88888 /* DiaryDayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6C7F22291D2A6300B88888 /* DiaryDayModel.swift */; };
 		CC9F969628F7E0B100E4B68A /* MyDiaryPagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9F969528F7E0B100E4B68A /* MyDiaryPagesViewModel.swift */; };
 		CCBF68932924D8A800AD2B63 /* CalendarYearPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBF68922924D8A800AD2B63 /* CalendarYearPickerView.swift */; };
+		CCBF689529260C7700AD2B63 /* DiaryDaysSegmentedControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBF689429260C7700AD2B63 /* DiaryDaysSegmentedControlView.swift */; };
 		CCD6D58C29135A7300013367 /* DiaryConfigCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD6D58B29135A7300013367 /* DiaryConfigCellViewModel.swift */; };
 		CCD6D58E2914F6C600013367 /* DiaryConfigModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD6D58D2914F6C600013367 /* DiaryConfigModel.swift */; };
 		CCE1806F28E5919B00AF06DB /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1806E28E5919B00AF06DB /* SignInViewController.swift */; };
@@ -227,6 +228,7 @@
 		CC6C7F22291D2A6300B88888 /* DiaryDayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDayModel.swift; sourceTree = "<group>"; };
 		CC9F969528F7E0B100E4B68A /* MyDiaryPagesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyDiaryPagesViewModel.swift; sourceTree = "<group>"; };
 		CCBF68922924D8A800AD2B63 /* CalendarYearPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarYearPickerView.swift; sourceTree = "<group>"; };
+		CCBF689429260C7700AD2B63 /* DiaryDaysSegmentedControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDaysSegmentedControlView.swift; sourceTree = "<group>"; };
 		CCD6D58B29135A7300013367 /* DiaryConfigCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryConfigCellViewModel.swift; sourceTree = "<group>"; };
 		CCD6D58D2914F6C600013367 /* DiaryConfigModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryConfigModel.swift; sourceTree = "<group>"; };
 		CCE1806E28E5919B00AF06DB /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 				B9901C06291C2A2C00AF92DE /* MyDiaryDaysViewModel.swift */,
 				B9901C08291C2A3800AF92DE /* MyDiaryDaysModel.swift */,
 				B9901C0C291CA4B900AF92DE /* DiaryDaysCollectionView */,
+				CCBF689429260C7700AD2B63 /* DiaryDaysSegmentedControlView.swift */,
 			);
 			path = MyDiaryDays;
 			sourceTree = "<group>";
@@ -933,6 +936,7 @@
 				E2C27502290D62EB00319885 /* DiaryCollectionViewModel.swift in Sources */,
 				0A5235B028F8510C00AC77AC /* UIFont+.swift in Sources */,
 				0A3ED14128F98956000D55D8 /* MyPageViewModel.swift in Sources */,
+				CCBF689529260C7700AD2B63 /* DiaryDaysSegmentedControlView.swift in Sources */,
 				CC3414082919310700A1FD17 /* DiaryColorCellViewModel.swift in Sources */,
 				CC6BD74428EBFA80001ED665 /* DiaryConfigViewController.swift in Sources */,
 				B9901C07291C2A2C00AF92DE /* MyDiaryDaysViewModel.swift in Sources */,

--- a/MacC-GoldenRatio/MacC-GoldenRatio.xcodeproj/project.pbxproj
+++ b/MacC-GoldenRatio/MacC-GoldenRatio.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		CC6C7F21291CEB3600B88888 /* DiaryDaysCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6C7F20291CEB3600B88888 /* DiaryDaysCell.swift */; };
 		CC6C7F23291D2A6300B88888 /* DiaryDayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6C7F22291D2A6300B88888 /* DiaryDayModel.swift */; };
 		CC9F969628F7E0B100E4B68A /* MyDiaryPagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9F969528F7E0B100E4B68A /* MyDiaryPagesViewModel.swift */; };
+		CCBF68932924D8A800AD2B63 /* CalendarYearPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBF68922924D8A800AD2B63 /* CalendarYearPickerView.swift */; };
 		CCD6D58C29135A7300013367 /* DiaryConfigCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD6D58B29135A7300013367 /* DiaryConfigCellViewModel.swift */; };
 		CCD6D58E2914F6C600013367 /* DiaryConfigModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD6D58D2914F6C600013367 /* DiaryConfigModel.swift */; };
 		CCE1806F28E5919B00AF06DB /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1806E28E5919B00AF06DB /* SignInViewController.swift */; };
@@ -225,6 +226,7 @@
 		CC6C7F20291CEB3600B88888 /* DiaryDaysCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDaysCell.swift; sourceTree = "<group>"; };
 		CC6C7F22291D2A6300B88888 /* DiaryDayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDayModel.swift; sourceTree = "<group>"; };
 		CC9F969528F7E0B100E4B68A /* MyDiaryPagesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyDiaryPagesViewModel.swift; sourceTree = "<group>"; };
+		CCBF68922924D8A800AD2B63 /* CalendarYearPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarYearPickerView.swift; sourceTree = "<group>"; };
 		CCD6D58B29135A7300013367 /* DiaryConfigCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryConfigCellViewModel.swift; sourceTree = "<group>"; };
 		CCD6D58D2914F6C600013367 /* DiaryConfigModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryConfigModel.swift; sourceTree = "<group>"; };
 		CCE1806E28E5919B00AF06DB /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 				CC40BC1928EEAE2400DF48E1 /* CalendarDateCollectionViewCell.swift */,
 				CC40BC1B28EEAEB200DF48E1 /* Day.swift */,
 				CC40BC1D28EEAEDA00DF48E1 /* MonthMetadata.swift */,
+				CCBF68922924D8A800AD2B63 /* CalendarYearPickerView.swift */,
 			);
 			path = CalendarView;
 			sourceTree = "<group>";
@@ -987,6 +990,7 @@
 				CC65515228F0877900E637A2 /* MyDiaryPagesViewCollectionViewCell.swift in Sources */,
 				0AAB2AD328EB14A8009FBD96 /* UIView+.swift in Sources */,
 				E28F080428E4655100832F4A /* SceneDelegate.swift in Sources */,
+				CCBF68932924D8A800AD2B63 /* CalendarYearPickerView.swift in Sources */,
 				E2DA8F6228F856A10098DD94 /* MyAlbumPhotoViewController.swift in Sources */,
 				E2838BE6291E38EE0013DD82 /* MapModel.swift in Sources */,
 				E2FA41A128F4752D00BBA354 /* DiaryCollectionViewCell.swift in Sources */,

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/Date+.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/Date+.swift
@@ -32,4 +32,12 @@ extension Date {
         }
         return dates
     }
+    
+    init(_ dateString:String) {
+        let dateStringFormatter = DateFormatter()
+        dateStringFormatter.dateFormat = "yyyy/MM"
+        dateStringFormatter.locale = Locale(identifier: "ko")
+        let date = dateStringFormatter.date(from: dateString)!
+        self.init(timeInterval:0, since:date)
+    }
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/UIView+.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Extensions/UIView+.swift
@@ -40,15 +40,15 @@ extension UIView {
     }
 	
 	func showToastMessage(_ message: String, font: UIFont = UIFont(name: "EF_Diary", size: 12) ?? UIFont.systemFont(ofSize: 12)) {
-		let toastLabel = UILabel(frame: CGRect(x: self.bounds.midX-90, y: self.frame.height - 150, width: 180, height: 30))
+		let toastLabel = UILabel(frame: CGRect(x: self.bounds.midX-90, y: self.frame.height - 150, width: 180, height: 42))
 		
-		toastLabel.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+		toastLabel.backgroundColor = UIColor.black
 		toastLabel.textColor = UIColor.white
 		toastLabel.numberOfLines = 2
 		toastLabel.font = font
 		toastLabel.text = message
 		toastLabel.textAlignment = .center
-		toastLabel.layer.cornerRadius = 15
+		toastLabel.layer.cornerRadius = 20
 		toastLabel.clipsToBounds = true
 		
 		self.addSubview(toastLabel)

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerFooterView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerFooterView.swift
@@ -22,6 +22,7 @@ class CalendarPickerFooterView: UIView {
         button.backgroundColor = .sandbrownColor
         button.layer.cornerRadius = 5
         button.addTarget(self, action: #selector(selectButtonTapped), for: .touchUpInside)
+        button.isEnabled = false
         return button
     }()
     

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerHeaderView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerHeaderView.swift
@@ -21,6 +21,14 @@ class CalendarPickerHeaderView: UIView {
         return label
     }()
     
+    lazy var monthPickerButton: UIButton = {
+        let button = UIButton()
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold, scale: .default)
+        button.setImage(UIImage(systemName: "chevron.right", withConfiguration: imageConfig), for: .normal)
+        button.tintColor = .sandbrownColor
+        return button
+    }()
+    
     lazy var previousMonthButton: UIButton = {
         let button = UIButton()
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 22, weight: .semibold, scale: .default)
@@ -80,7 +88,7 @@ class CalendarPickerHeaderView: UIView {
         layer.cornerCurve = .continuous
         layer.cornerRadius = 15
 
-        [monthLabel, previousMonthButton, nextMonthButton, dayOfWeekStackView].forEach {
+        [monthLabel, monthPickerButton, previousMonthButton, nextMonthButton, dayOfWeekStackView].forEach {
             self.addSubview($0)
         }
         
@@ -126,6 +134,12 @@ class CalendarPickerHeaderView: UIView {
         monthLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(16)
             $0.leading.equalToSuperview().inset(16)
+        }
+        
+        monthPickerButton.snp.makeConstraints {
+            $0.leading.equalTo(monthLabel.snp.trailing)
+            $0.centerY.equalTo(monthLabel)
+            $0.width.height.equalTo(20)
         }
         
         previousMonthButton.snp.makeConstraints {

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerHeaderView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerHeaderView.swift
@@ -50,7 +50,7 @@ class CalendarPickerHeaderView: UIView {
     private lazy var dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.calendar = Calendar(identifier: .gregorian)
-        dateFormatter.locale = Locale.autoupdatingCurrent
+        dateFormatter.locale = Locale(identifier: "ko")
         dateFormatter.setLocalizedDateFormatFromTemplate("MMMM y")
         return dateFormatter
     }()

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerHeaderView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerHeaderView.swift
@@ -23,8 +23,11 @@ class CalendarPickerHeaderView: UIView {
     
     lazy var monthPickerButton: UIButton = {
         let button = UIButton()
-        let imageConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold, scale: .default)
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold, scale: .unspecified)
         button.setImage(UIImage(systemName: "chevron.right", withConfiguration: imageConfig), for: .normal)
+        button.imageView?.contentMode = .scaleAspectFit
+        button.contentHorizontalAlignment = .trailing
+        button.backgroundColor = .clear
         button.tintColor = .sandbrownColor
         return button
     }()
@@ -137,9 +140,10 @@ class CalendarPickerHeaderView: UIView {
         }
         
         monthPickerButton.snp.makeConstraints {
-            $0.leading.equalTo(monthLabel.snp.trailing)
+            $0.leading.equalTo(monthLabel)
             $0.centerY.equalTo(monthLabel)
-            $0.width.height.equalTo(20)
+            $0.height.equalTo(30)
+            $0.width.equalTo(monthLabel).multipliedBy(1.1)
         }
         
         previousMonthButton.snp.makeConstraints {

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerViewController.swift
@@ -42,11 +42,22 @@ class CalendarPickerViewController: UIViewController {
         })
     
     lazy var footerView = CalendarPickerFooterView(timeInterval: dateInterval, selectButtonCompletionHanlder: { [weak self] in
-            guard let self = self else { return }
-            
+        guard let self = self else { return }
+        
+        if self.monthPicker.isHidden == true {
             self.selectedDateChanged(self.dateInterval)
             self.dismissCalendar()
-        })
+        } else {
+            
+            self.monthPicker.isHidden = true
+            UIView.animate(withDuration: 0.2) {
+                let scale = CGAffineTransform(rotationAngle: 0)
+                self.headerView.monthPickerButton.transform = scale
+            }
+            self.updateFooterButtonLabel(day: nil)
+            self.collectionView.reloadData()
+        }
+    })
     
     private lazy var closeButton: UIButton = {
         let button = UIButton()
@@ -57,6 +68,8 @@ class CalendarPickerViewController: UIViewController {
         return button
     }()
     
+    private let monthPicker = CalendarYearPickerView(frame: CGRect.zero)
+    
     // MARK: Calendar Data Values
     
     private let selectedStartDate: Date
@@ -66,6 +79,7 @@ class CalendarPickerViewController: UIViewController {
             days = generateDaysInMonth(for: startBaseDate)
             collectionView.reloadData()
             headerView.baseDate = startBaseDate
+            monthPicker.setAvailableDate(date: startBaseDate)
         }
     }
     private var endBaseDate: Date? {
@@ -73,7 +87,6 @@ class CalendarPickerViewController: UIViewController {
             collectionView.reloadData()
         }
     }
-    
     
     private lazy var days = generateDaysInMonth(for: startBaseDate)
     
@@ -103,7 +116,7 @@ class CalendarPickerViewController: UIViewController {
             self.startBaseDate = dateArray[0]
         }
         self.selectedDateChanged = selectedDateChanged
-
+        
         super.init(nibName: nil, bundle: nil)
         
         modalPresentationStyle = .overCurrentContext
@@ -119,12 +132,36 @@ class CalendarPickerViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        collectionView.backgroundColor = .systemGroupedBackground
         
-        [dimmedBackgroundView, collectionView, headerView, footerView, closeButton].forEach {
+        attribute()
+        layout()
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        collectionView.reloadData()
+    }
+    
+    private func attribute() {
+        collectionView.backgroundColor = .systemGroupedBackground
+        collectionView.register(CalendarDateCollectionViewCell.self, forCellWithReuseIdentifier: CalendarDateCollectionViewCell.reuseIdentifier)
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        
+        headerView.baseDate = startBaseDate
+        headerView.monthPickerButton.addTarget(self, action: #selector(didTapMonthPickerButton), for: .touchUpInside)
+        
+        monthPicker.isHidden = true
+        monthPicker.dataSource = self
+        monthPicker.delegate = self
+        monthPicker.setAvailableDate(date: startBaseDate)
+        
+        [dimmedBackgroundView, collectionView, headerView, footerView, closeButton, monthPicker].forEach {
             view.addSubview($0)
         }
-        
+    }
+    
+    private func layout() {
         dimmedBackgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
@@ -153,21 +190,40 @@ class CalendarPickerViewController: UIViewController {
             $0.size.equalTo(device.calendarCloseButtonSize)
         }
         
-        collectionView.register(CalendarDateCollectionViewCell.self, forCellWithReuseIdentifier: CalendarDateCollectionViewCell.reuseIdentifier)
-        
-        collectionView.dataSource = self
-        collectionView.delegate = self
-        
-        headerView.baseDate = startBaseDate
-    }
-    
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        collectionView.reloadData()
+        monthPicker.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(-30)
+            $0.centerX.equalTo(collectionView)
+            $0.width.equalTo(collectionView).inset(10)
+            $0.height.equalTo(collectionView).offset(20)
+        }
     }
     
     @objc private func dismissCalendar() {
         self.dismiss(animated: true, completion: nil)
+    }
+    
+    @objc private func didTapMonthPickerButton() {
+        self.monthPicker.isHidden.toggle()
+        
+        if monthPicker.isHidden == true {
+            collectionView.reloadData()
+            self.footerView.buttonLabel = "날짜를 선택하세요"
+            self.footerView.selectButton.isEnabled = false
+            UIView.animate(withDuration: 0.2) {
+                let scale = CGAffineTransform(rotationAngle: 0)
+                self.headerView.monthPickerButton.transform = scale
+                self.monthPicker.alpha = 0
+            }
+        } else {
+            self.dateInterval.removeAll()
+            self.footerView.buttonLabel = "확인"
+            self.footerView.selectButton.isEnabled = true
+            UIView.animate(withDuration: 0.2) {
+                let scale = CGAffineTransform(rotationAngle: .pi/2)
+                self.headerView.monthPickerButton.transform = scale
+                self.monthPicker.alpha = 1
+            }
+        }
     }
 }
 
@@ -216,24 +272,24 @@ private extension CalendarPickerViewController {
     
     func generateStartOfNextMonth(
         using firstDayOfDisplayedMonth: Date) -> [Day] {
-        guard
-            let lastDayInMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: firstDayOfDisplayedMonth)
-        else {
-            return []
-        }
-        
-        let additionalDays = 7 - calendar.component(.weekday, from: lastDayInMonth)
-        guard additionalDays > 0 else {
-            return []
-        }
-        
-        let days: [Day] = (1...additionalDays)
-            .map {
-                generateDay(offsetBy: $0, for: lastDayInMonth, isWithinDisplayedMonth: false)
+            guard
+                let lastDayInMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: firstDayOfDisplayedMonth)
+            else {
+                return []
             }
-        
-        return days
-    }
+            
+            let additionalDays = 7 - calendar.component(.weekday, from: lastDayInMonth)
+            guard additionalDays > 0 else {
+                return []
+            }
+            
+            let days: [Day] = (1...additionalDays)
+                .map {
+                    generateDay(offsetBy: $0, for: lastDayInMonth, isWithinDisplayedMonth: false)
+                }
+            
+            return days
+        }
     
     enum CalendarDataError: Error {
         case metadataGeneration
@@ -313,11 +369,16 @@ extension CalendarPickerViewController: UICollectionViewDelegateFlowLayout {
         return UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
     }
     
-    private func updateFooterButtonLabel(day: Day) {
+    private func updateFooterButtonLabel(day: Day?) {
         if dateInterval.count == 2 {
             dateInterval.removeAll()
         }
-        dateInterval.append(day.date)
+        
+        if let day = day {
+            dateInterval.append(day.date)
+        } else {
+            dateInterval.removeAll()
+        }
         
         switch dateInterval.count {
         case 1:
@@ -343,6 +404,56 @@ extension CalendarPickerViewController: UICollectionViewDelegateFlowLayout {
             self.footerView.selectButton.isEnabled = false
             self.footerView.buttonLabel = "날짜를 선택하세요"
         }
+    }
+}
+
+extension CalendarPickerViewController: UIPickerViewDelegate, UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 2
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        guard let pickerView = pickerView as? CalendarYearPickerView else { return 0 }
+        
+        switch component {
+        case 0:
+            return pickerView.availableYear.count
+        case 1:
+            return pickerView.allMonth.count
+        default:
+            return 0
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        
+        guard let pickerView = pickerView as? CalendarYearPickerView else { return nil }
+        
+        switch component {
+        case 0:
+            return "\(pickerView.availableYear[row])년"
+        case 1:
+            return "\(pickerView.allMonth[row])월"
+        default:
+            return ""
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        
+        guard let pickerView = pickerView as? CalendarYearPickerView else { return }
+        
+        switch component {
+        case 0:
+            pickerView.selectedYear = pickerView.availableYear[row]
+            
+        case 1:
+            pickerView.selectedMonth = pickerView.allMonth[row]
+        default:
+            break
+        }
+        
+        startBaseDate = Date("\(pickerView.selectedYear)/\(pickerView.selectedMonth)")
     }
 }
 

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerViewController.swift
@@ -52,7 +52,7 @@ class CalendarPickerViewController: UIViewController {
             self.monthPicker.isHidden = true
             UIView.animate(withDuration: 0.2) {
                 let scale = CGAffineTransform(rotationAngle: 0)
-                self.headerView.monthPickerButton.transform = scale
+                self.headerView.monthPickerButton.imageView?.transform = scale
             }
             self.updateFooterButtonLabel(day: nil)
             self.collectionView.reloadData()
@@ -210,8 +210,8 @@ class CalendarPickerViewController: UIViewController {
             self.footerView.buttonLabel = "날짜를 선택하세요"
             self.footerView.selectButton.isEnabled = false
             UIView.animate(withDuration: 0.2) {
-                let scale = CGAffineTransform(rotationAngle: 0)
-                self.headerView.monthPickerButton.transform = scale
+                let angle = CGAffineTransform(rotationAngle: 0)
+                self.headerView.monthPickerButton.imageView?.transform = angle
                 self.monthPicker.alpha = 0
             }
         } else {
@@ -219,8 +219,8 @@ class CalendarPickerViewController: UIViewController {
             self.footerView.buttonLabel = "확인"
             self.footerView.selectButton.isEnabled = true
             UIView.animate(withDuration: 0.2) {
-                let scale = CGAffineTransform(rotationAngle: .pi/2)
-                self.headerView.monthPickerButton.transform = scale
+                var angle = CGAffineTransform(rotationAngle: .pi/2)
+                self.headerView.monthPickerButton.imageView?.transform = angle
                 self.monthPicker.alpha = 1
             }
         }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarPickerViewController.swift
@@ -219,7 +219,7 @@ class CalendarPickerViewController: UIViewController {
             self.footerView.buttonLabel = "확인"
             self.footerView.selectButton.isEnabled = true
             UIView.animate(withDuration: 0.2) {
-                var angle = CGAffineTransform(rotationAngle: .pi/2)
+                let angle = CGAffineTransform(rotationAngle: .pi/2)
                 self.headerView.monthPickerButton.imageView?.transform = angle
                 self.monthPicker.alpha = 1
             }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarYearPickerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarYearPickerView.swift
@@ -28,9 +28,11 @@ class CalendarYearPickerView: UIPickerView {
     func setAvailableDate(date: Date) {
         let formatterYear = DateFormatter()
         formatterYear.dateFormat = "yyyy"
+        
+        let currentYear = formatterYear.string(from: Date())
         todayYear = formatterYear.string(from: date)
-            
-        for i in 1970...Int(todayYear)!+5 {
+        
+        for i in 1970...Int(currentYear)!+5 {
             availableYear.append(i)
         }
         

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarYearPickerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/DiaryConfig/CalendarView/CalendarYearPickerView.swift
@@ -1,0 +1,48 @@
+//
+//  CalendarYearPickerView.swift
+//  MacC-GoldenRatio
+//
+//  Created by DongKyu Kim on 2022/11/16.
+//
+
+import UIKit
+
+class CalendarYearPickerView: UIPickerView {
+    
+    var availableYear: [Int] = []
+    var allMonth: [Int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    var selectedYear = 0
+    var selectedMonth = 0
+    var todayYear = "0"
+    var todayMonth = "0"
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .systemGroupedBackground
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setAvailableDate(date: Date) {
+        let formatterYear = DateFormatter()
+        formatterYear.dateFormat = "yyyy"
+        todayYear = formatterYear.string(from: date)
+            
+        for i in 1970...Int(todayYear)!+5 {
+            availableYear.append(i)
+        }
+        
+        let formatterMonth = DateFormatter()
+        formatterMonth.dateFormat = "MM"
+        todayMonth = formatterMonth.string(from: date)
+            
+        selectedYear = Int(todayYear)!
+        selectedMonth = Int(todayMonth)!
+        
+        self.selectRow(selectedYear - 1970, inComponent: 0, animated: true)
+        self.selectRow(selectedMonth - 1, inComponent: 1, animated: true)
+    }
+    
+}

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryDays/DiaryDaysSegmentedControlView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryDays/DiaryDaysSegmentedControlView.swift
@@ -1,0 +1,37 @@
+//
+//  DiaryDaysSegmentedControlView.swift
+//  MacC-GoldenRatio
+//
+//  Created by DongKyu Kim on 2022/11/17.
+//
+
+import UIKit
+
+class DiaryDaysSegmentedControlView: UISegmentedControl {
+    
+    let configuration = UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .medium)
+
+    let selectedAttribute = [NSAttributedString.Key.foregroundColor: UIColor.sandbrownColor]
+    let normalAttribute = [NSAttributedString.Key.foregroundColor: UIColor.stickerBackgroundColor]
+    
+    override init(items: [Any]?) {
+        let dayButton = UIImage(systemName: "doc.text.image", withConfiguration: configuration) ?? UIImage()
+        let albumButton = UIImage(systemName: "photo", withConfiguration: configuration) ?? UIImage()
+        let mapButton = UIImage(systemName: "mappin.and.ellipse", withConfiguration: configuration) ?? UIImage()
+        
+        super.init(items: [dayButton, albumButton, mapButton])
+        
+        attribute()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func attribute() {
+        self.setTitleTextAttributes(selectedAttribute, for:.selected)
+        self.setTitleTextAttributes(normalAttribute, for: .normal)
+        self.backgroundColor = .clear
+        self.selectedSegmentIndex = 0
+    }
+}

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryDays/DiaryDaysSegmentedControlView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryDays/DiaryDaysSegmentedControlView.swift
@@ -9,18 +9,22 @@ import UIKit
 
 class DiaryDaysSegmentedControlView: UISegmentedControl {
     
-    let configuration = UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .medium)
-
-    let selectedAttribute = [NSAttributedString.Key.foregroundColor: UIColor.sandbrownColor]
-    let normalAttribute = [NSAttributedString.Key.foregroundColor: UIColor.stickerBackgroundColor]
+    private lazy var underlineView: UIView = {
+      let width = self.bounds.size.width / CGFloat(self.numberOfSegments)
+      let height = 5.0
+      let xPosition = CGFloat(self.selectedSegmentIndex * Int(width))
+      let yPosition = self.bounds.size.height - 5.0
+      let frame = CGRect(x: xPosition, y: yPosition, width: width, height: height)
+      let view = UIView(frame: frame)
+      view.backgroundColor = UIColor.sandbrownColor
+      self.addSubview(view)
+      return view
+    }()
     
     override init(items: [Any]?) {
-        let dayButton = UIImage(systemName: "doc.text.image", withConfiguration: configuration) ?? UIImage()
-        let albumButton = UIImage(systemName: "photo", withConfiguration: configuration) ?? UIImage()
-        let mapButton = UIImage(systemName: "mappin.and.ellipse", withConfiguration: configuration) ?? UIImage()
         
-        super.init(items: [dayButton, albumButton, mapButton])
-        
+        super.init(items: ["", "", ""])
+        removeBackgroundAndDivider()
         attribute()
     }
     
@@ -28,10 +32,31 @@ class DiaryDaysSegmentedControlView: UISegmentedControl {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        let underlineFinalXPosition = (self.bounds.width / CGFloat(self.numberOfSegments)) * CGFloat(self.selectedSegmentIndex)
+        
+        UIView.animate(withDuration: 0.15, animations: {
+                self.underlineView.frame.origin.x = underlineFinalXPosition
+            })
+    }
+    
     private func attribute() {
-        self.setTitleTextAttributes(selectedAttribute, for:.selected)
-        self.setTitleTextAttributes(normalAttribute, for: .normal)
         self.backgroundColor = .clear
+        self.layer.maskedCorners = .init()
         self.selectedSegmentIndex = 0
+    }
+    
+    private func removeBackgroundAndDivider() {
+        let image = UIImage().withRenderingMode(.alwaysOriginal)
+        
+        self.setBackgroundImage(image, for: .normal, barMetrics: .default)
+        self.setBackgroundImage(image, for: .selected, barMetrics: .default)
+        self.setBackgroundImage(image, for: .highlighted, barMetrics: .default)
+
+        self.setDividerImage(image, forLeftSegmentState: .selected, rightSegmentState: .normal, barMetrics: .default)
+        self.setDividerImage(image, forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
+        self.setDividerImage(image, forLeftSegmentState: .normal, rightSegmentState: .selected, barMetrics: .default)
     }
 }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryDays/MyDiaryDaysViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryDays/MyDiaryDaysViewController.swift
@@ -29,6 +29,7 @@ class MyDiaryDaysViewController: UIViewController {
         super.viewWillAppear(animated)
     }
     
+    // MARK: Components
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
@@ -58,22 +59,12 @@ class MyDiaryDaysViewController: UIViewController {
         return view
     }()
     
-    private lazy var segmentedControl: UISegmentedControl = {
-        let configuration = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .medium)
-        let dayButton = UIImage(systemName: "doc.text.image", withConfiguration: configuration) ?? UIImage()
-        let albumButton = UIImage(systemName: "photo", withConfiguration: configuration) ?? UIImage()
-        let mapButton = UIImage(systemName: "mappin.and.ellipse", withConfiguration: configuration) ?? UIImage()
-        let control = UISegmentedControl(items: [dayButton, albumButton, mapButton])
-        let selectedAttribute = [NSAttributedString.Key.foregroundColor: UIColor.sandbrownColor]
-        control.setTitleTextAttributes(selectedAttribute, for:.selected)
-        control.selectedSegmentIndex = 0
-        control.backgroundColor = .clear
-        return control
-    }()
-
+    let segmentedControl = DiaryDaysSegmentedControlView(items: nil)
+    
     let diaryDaysCollectionView = DiaryDaysCollectionView()
     let albumCollectionView = AlbumCollectionView()
     let mapView = MapView()
+    
     
     // MARK: Bind
     func bind(_ viewModel: MyDiaryDaysViewModel) {
@@ -129,6 +120,7 @@ class MyDiaryDaysViewController: UIViewController {
             .disposed(by: disposeBag)
     }
     
+    
     // MARK: Attribute & Layout
     private func attribute() {
         // TODO: UIColor+ 추가 후 수정
@@ -136,7 +128,6 @@ class MyDiaryDaysViewController: UIViewController {
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
         NotificationCenter.default.addObserver(self, selector: #selector(mapListHalfModal(notification:)), name: .mapAnnotationTapped, object: nil)
-        
     }
     
     private func layout() {
@@ -171,13 +162,13 @@ class MyDiaryDaysViewController: UIViewController {
         segmentedControl.snp.makeConstraints {
             $0.top.equalTo(dividerView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(44)
+            $0.height.equalTo(67)
         }
         
         [diaryDaysCollectionView, albumCollectionView, mapView].forEach {
             view.addSubview($0)
             $0.snp.makeConstraints{
-                $0.top.equalTo(segmentedControl.snp.bottom)
+                $0.top.equalTo(segmentedControl.snp.bottom).offset(1)
                 $0.bottom.width.equalToSuperview()
                 $0.height.lessThanOrEqualToSuperview()
             }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryDays/MyDiaryDaysViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/MyDiaryDays/MyDiaryDaysViewController.swift
@@ -73,12 +73,18 @@ class MyDiaryDaysViewController: UIViewController {
         self.segmentedControl.rx.selectedSegmentIndex
             .bind(to: viewModel.segmentIndex)
             .disposed(by: disposeBag)
-        
+                
         viewModel.selectedViewType
             .drive(onNext: { state in
                 [self.diaryDaysCollectionView, self.albumCollectionView, self.mapView].enumerated().forEach { index, view in
                     view.isHidden = state[index]
                 }
+                
+                let configuration = UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .medium)
+                
+                self.segmentedControl.setImage(UIImage(systemName: "doc.text.image", withConfiguration: configuration)?.withTintColor(state[0] ? .stickerBackgroundColor : .sandbrownColor , renderingMode: .alwaysOriginal), forSegmentAt: 0)
+                self.segmentedControl.setImage(UIImage(systemName: "photo", withConfiguration: configuration)?.withTintColor(state[1] ? .stickerBackgroundColor : .sandbrownColor , renderingMode: .alwaysOriginal), forSegmentAt: 1)
+                self.segmentedControl.setImage(UIImage(systemName: "mappin.and.ellipse", withConfiguration: configuration)?.withTintColor(state[2] ? .stickerBackgroundColor : .sandbrownColor , renderingMode: .alwaysOriginal), forSegmentAt: 2)
             })
             .disposed(by: disposeBag)
         
@@ -123,8 +129,7 @@ class MyDiaryDaysViewController: UIViewController {
     
     // MARK: Attribute & Layout
     private func attribute() {
-        // TODO: UIColor+ 추가 후 수정
-        self.view.backgroundColor = UIColor(named: "appBackgroundColor")!
+        self.view.backgroundColor = UIColor.appBackgroundColor
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
         NotificationCenter.default.addObserver(self, selector: #selector(mapListHalfModal(notification:)), name: .mapAnnotationTapped, object: nil)
@@ -168,7 +173,7 @@ class MyDiaryDaysViewController: UIViewController {
         [diaryDaysCollectionView, albumCollectionView, mapView].forEach {
             view.addSubview($0)
             $0.snp.makeConstraints{
-                $0.top.equalTo(segmentedControl.snp.bottom).offset(1)
+                $0.top.equalTo(segmentedControl.snp.bottom)
                 $0.bottom.width.equalToSuperview()
                 $0.height.lessThanOrEqualToSuperview()
             }

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/SignIn/SignInViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/ViewControllers/SignIn/SignInViewController.swift
@@ -81,6 +81,7 @@ class SignInViewController: UIViewController {
         super.viewDidLoad()
         
         view.backgroundColor = UIColor(patternImage: UIImage(named: "backgroundTexture.png") ?? UIImage())
+        self.initialSetup()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -91,7 +92,7 @@ class SignInViewController: UIViewController {
                 FirestoreClient().isExistingUser(user.uid) { value in
                     if value {
                         self.showMainView()
-                    }else{
+                    } else {
                         self.setup()
                     }
                 }
@@ -100,11 +101,29 @@ class SignInViewController: UIViewController {
             }
         }
     }
-    private func setup() {
-        [appLogo, appTitle, appleLoginButton].forEach {
+    
+    private func initialSetup() {
+        navigationController?.isNavigationBarHidden = true
+        [appLogo, appTitle].forEach {
             view.addSubview($0)
         }
-        navigationController?.isNavigationBarHidden = true
+        
+        appLogo.snp.makeConstraints {
+            $0.width.equalToSuperview().dividedBy(3.9)
+            $0.height.equalTo(appLogo.snp.width).multipliedBy(0.8)
+            $0.bottom.equalTo(appTitle.snp.top).offset(-70)
+            $0.centerX.equalToSuperview()
+        }
+        
+        appTitle.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview().offset(70)
+        }
+    }
+    
+    private func setup() {
+        
+        view.addSubview(appleLoginButton)
         
         appLogo.snp.makeConstraints {
             $0.width.equalToSuperview().dividedBy(3.9)


### PR DESCRIPTION
 ## Changes

- 캘린더 년/월 영어 -> 한글로 수정
- 캘런더 년/월을 선택할 수 있는 Picker 추가
- ToastMessage UI 수정
- DiaryDaysView의 Segmented Control UI 수정
- 로그인 로딩 화면에서 앱 로고 추가

<br>

## 작업 사항

### 1. 캘린더 년/월 한글 수정
캘린더의 Locale 설정을 통해 날짜를 한글로 변경할 수 있었습니다.
```swift
dateFormatter.locale = Locale(identifier: "ko")
```

### 2. 캘런더 년/월을 선택할 수 있는 Picker 추가
- 버튼을 통한 날짜 이동의 불편함을 개선하기 위해 [년/월]을 선택할 수 있는 Picker를 추가하였습니다.
- 기존 UIDatePicker의 캘린더 방식과 동일한 picker를 사용하려 했는데, UIDatePicker 자체에서는 [년/월]만 선택할 수 있는 picker가 지원되지 않았습니다.
- UIDatePicker의 `.wheel` 스타일의 모드 중 `.date` 모드의 경우, Fig.2과 같이 [년/월/일] 을 선택할 수 있는 picker만 제공되며, Fig.3과 같이 캘린더 형식의 UIDatePicker에서 [년/월]을 선택할 수 있는 방식과 동일한 방식으로 진행하고자 Fig.1과 같이 구현하였습니다.

| Fig.1 CustomPicker | Fig.2 UIDatePicker - .date모드 | Fig.3 캘린더 타입의 UIDatePicker |
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/45297745/202638498-ac84b849-2a57-4b7f-9187-79a76601834a.png" width="250" height="541"/>|<img src="https://user-images.githubusercontent.com/45297745/202638521-6074e80b-b627-4e42-a7ac-dbf0e0f08f39.png" width="250" height="541"/>|<img src="https://user-images.githubusercontent.com/45297745/202638515-031c8091-617f-423b-8c7b-846f12c3101c.gif" width="250" height="541"/>|

### 3. ToastMessage UI 수정
<img src="https://user-images.githubusercontent.com/45297745/202639480-caf19654-75a0-4dfa-833e-e986c77e3eb4.png" width="250" height="541"/>
ToastMessage의 프레임 크기 및 색상을 수정하였습니다.

### 4. DiaryDaysView의 Segmented Control UI 수정
<img src="https://user-images.githubusercontent.com/45297745/202641301-1487f568-cdf2-463b-95a7-e0cde00026d5.gif" width="250" height="541"/>

<레퍼런스>
[[iOS - swift] 2. UISegmentedControl - 커스텀 방법, PageViewController와 사용 방법](https://ios-development.tistory.com/963)

- 해당 레퍼런스의 방식대로 언더바 뷰와 색 변경 등을 활용할 때, 꽤 자연스러운 효과를 확인할 수 있었습니다.
- 하지만 위의 레퍼런스와 같이 Segmented Control의 item이 텍스트일때는 selectedItem의 색상이 원하는대로 잘 변경되는데, 이미지의 경우에는 제대로 컬러 적용이 되지 않았습니다.
- 위의 레퍼런스의 경우, SegmentedControl의 background를 빈 이미지로 설정해서 아무것도 안보이도록 설정하는데, 이 과정에서 SegmentedControl의 item에 있는 이미지가 가진 속성도 안보이도록(?) 설정되는 것으로 생각했습니다.
- 해당 Segmented Control의 `tintColor` 속성을 통해 색을 변경할 수는 있었지만, 최초로 그려진 뷰 이후에 `tintColor`가 바뀌지 않는 문제가 있었습니다 (이유는 아직 잘 모르겠습니다.)
- 결국 해당 아이템이 선택될 때 마다 색상 정보를 가진 이미지를 버튼 아이템으로 세팅하는 방법을 통해 구현하였습니다. (`selectedViewType`을 `subscribe` 했을 때 수행)
    
    ```swift
    self.segmentedControl.setImage(UIImage(systemName: "doc.text.image", withConfiguration: configuration)?.withTintColor(state[0] ? .stickerBackgroundColor : .sandbrownColor , renderingMode: .alwaysOriginal), forSegmentAt: 0)
    ... (다른 item도 동일한 방법으로 설정)
    ```
    
- 또, systemImage의 tintColor속성을 지정해 줄 때, `.withTintColor(state[0] ? .stickerBackgroundColor : .sandbrownColor , renderingMode: .alwaysOriginal)` 와 같이 `renderingMode`를 반드시 `.alwaysOriginal`로 설정해 주어야 합니다. (`renderingMode`와 관련된 간단한 소개는 아래 링크에 있습니다!)
    
    [[iOS] Image Rendering Mode](https://jinnify.tistory.com/60)


### 5. 로그인 로딩 화면에서 앱 로고 추가
<img src="https://user-images.githubusercontent.com/45297745/202641125-c7aa645c-23f3-4264-b516-d3859b2a4b41.gif" width="250" height="541"/>


## To Reviewers
- 작업 진행 중에 태스크가 조금씩 추가되다보니 PR이 커진 것 같습니다 ㅠㅠ 🙏
- 기존 Rx가 적용되지 않았던 상태에서 리팩토링이 적용되지는 않았습니다.
