### PR TITLE
Feat/#165 스티커수평정렬&햅틱피드백

### DIFF
--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Presenter/PageScene/View/StickerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Presenter/PageScene/View/StickerView.swift
@@ -231,8 +231,18 @@ class StickerView: UIView {
                           recognizer.location(in: superview).x - center.x)
 
         if let deltaAngle = deltaAngle {
-            let angleDiff = deltaAngle - angle
-            transform = CGAffineTransformMakeRotation(-angleDiff)
+            let angleDiff = deltaAngle - angle            
+            let newTransform = CGAffineTransformMakeRotation(-angleDiff)
+            let rotation = atan2(newTransform.b, newTransform.a)
+            
+            if rotation < -0.2 || rotation > 0.2 {
+                transform = newTransform
+            }else {
+                if transform != CGAffineTransform.identity {
+                    transform = CGAffineTransform.identity
+                    self.hapticFeedback.notificationOccurred(.success)
+                }
+            }
         }
     }
 

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Presenter/PageScene/View/StickerViewData.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Presenter/PageScene/View/StickerViewData.swift
@@ -130,4 +130,42 @@ class StickerViewData {
             })
             .disposed(by: disposeBag)
     }
+    
+    func updateItemFrameBoundsData(frame: CGRect, bounds: CGRect) {
+        self.itemObservable
+            .observe(on: MainScheduler.instance)
+            .take(1)
+            .map { item in
+                let itemFrame: [Double] = [frame.origin.x, frame.origin.y, frame.size.width, frame.size.height]
+                let itemBounds: [Double] = [0, 0, bounds.size.width, bounds.size.height]
+                
+                var newItem = item
+                newItem.itemFrame = itemFrame
+                newItem.itemBounds = itemBounds
+                
+                return newItem
+            }
+            .subscribe(onNext: {
+                self.itemObservable.onNext($0)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func updateItemTransform(transform: CGAffineTransform) {
+        self.itemObservable
+            .observe(on: MainScheduler.instance)
+            .take(1)
+            .map { item in
+                let itemTrasnform: [Double] = [transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty]
+                
+                var newItem = item
+                newItem.itemTransform = itemTrasnform
+
+                return newItem
+            }
+            .subscribe(onNext: {
+                self.itemObservable.onNext($0)
+            })
+            .disposed(by: disposeBag)
+    }
 }


### PR DESCRIPTION
## 작업사항

- Sticker Rotate Gesture ( 두 손가락으로 스티커 회전 ) 에 수평 맞추기 기능 추가
- Sticker Rotate Controller ( 스티커 오른쪽 아래 회전 버튼으로 스티커 회전 ) 에 수평 맞추기 기능 추가

<br>

## Changes

### Sticker Rotate Gesture ( 두 손가락으로 스티커 회전 ) 에 수평 맞추기 기능 추가
- 스티커를 회전시킬때 수평에 가까워지면 스티커를 수평으로 맞춥니다.
- 스티커를 수평으로 맞추는 기능이 동작하면 **Haptic Feedback**을 주어 사용자가 인식하도록 돕습니다.

### Sticker Rotate Controller ( 스티커 오른쪽 아래 회전 버튼으로 스티커 회전 ) 에 수평 맞추기 기능 추가
- 스티커를 회전시킬때 수평에 가까워지면 스티커를 수평으로 맞춥니다.
- 스티커를 수평으로 맞추는 기능이 동작하면 **Haptic Feedback**을 주어 사용자가 인식하도록 돕습니다.

<br>

## ScreenShot

<img src="https://user-images.githubusercontent.com/74828662/203573799-7340684d-88c8-4f35-ad18-852f54530eec.gif" width="250" height="541"/>


<br>

## 비고
### 수평 기능 발동 조건
- Sticker View의 회전각도가 -12° ~ 12° 에 들어오면 수평 (0°) 로 회전각을 맞춥니다.


<br>
