### PR TITLE
[design] #173 스티커 도구 버튼 이미지 변경

### DIFF
--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Presenter/PageScene/ViewController/PageEditModeViewController.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Presenter/PageScene/ViewController/PageEditModeViewController.swift
@@ -75,7 +75,9 @@ class PageEditModeViewController: UIViewController {
     
     private lazy var stickerToolButton: UIButton = {
         let button = UIButton()
-        let image = UIImage(systemName: "s.square", withConfiguration: UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold))
+        guard var image = UIImage(named: "stickerTool") else { return button }
+        image = image.withConfiguration(UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold))
+        
         button.setImage(image, for: .normal)
         button.tintColor = .black
         button.addTarget(self, action: #selector(onTapStickerButton), for: .touchUpInside)
@@ -85,7 +87,9 @@ class PageEditModeViewController: UIViewController {
     
     private lazy var textToolButton: UIButton = {
         let button = UIButton()
-        let image = UIImage(systemName: "t.square", withConfiguration: UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold))
+        guard var image = UIImage(named: "textTool") else { return button }
+        image = image.withConfiguration(UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold))
+
         button.setImage(image, for: .normal)
         button.tintColor = .black
         button.addTarget(self, action: #selector(onTapTextButton), for: .touchUpInside)


### PR DESCRIPTION
## 작업사항

- 스티커 도구 버튼 이미지 디자인 변경사항을 반영하였습니다.

<br>

## Changes

- PageEditModeVC에서 스티커 도구, 텍스트 도구 버튼 이미지를 변경하였습니다.

<br>

## ScreenShot

<img src="https://user-images.githubusercontent.com/74828662/204234210-9c3e910b-d63b-4178-82cc-c1468da8378e.png" width="270" height="600"/>

<br>

## To Reviewers

- 화면 디자인 변경이 많지 않습니다. 아래 도구 버튼만 봐주시면 될 것 같습니다.

<br>
