### PR TITLE
Fix/#186 ImageManager 메모리 이슈 해결

### DIFF
--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Classes/ImageManager.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Classes/ImageManager.swift
@@ -27,29 +27,34 @@ class ImageManager {
 
         // 디스크 캐시
         guard let imageFilePathURL = imageFilePathURL(urlString: urlString) else { return nil }
-        
         if fileManager.fileExists(atPath: imageFilePathURL.path) {
             guard let imageData = try? Data(contentsOf: imageFilePathURL) else { return nil }
             guard let image = UIImage(data: imageData) else { return nil }
 
-            cacheImages.setObject(image, forKey: nsString)
+            DispatchQueue.global().async { [weak self] in
+                self?.cacheImages.setObject(image, forKey: nsString)
+            }
+
             return image
         }
         return nil
     }
     
     func cacheImage(urlString: String, image: UIImage) {
-        // 메모리 캐시
-        let nsString = NSString(string: urlString)
-        cacheImages.setObject(image, forKey: nsString)
-        
-        // 디스크 캐시
-        guard let imageFilePathURL = imageFilePathURL(urlString: urlString) else { return }
-        
-        guard let imageData = image.pngData() else { return }
-        let imageNSData = NSData(data: imageData)
-        
-        imageNSData.write(to: imageFilePathURL, atomically: true)
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            // 이미지 압축
+            guard let compressedImageData = image.jpegData(compressionQuality: 0.4) else { return }
+            guard let compressedImage = UIImage(data: compressedImageData) else { return }
+            
+            // 메모리 캐시
+            let nsString = NSString(string: urlString)
+            self?.cacheImages.setObject(compressedImage, forKey: nsString)
+            
+            // 디스크 캐시
+            guard let imageFilePathURL = self?.imageFilePathURL(urlString: urlString) else { return }
+            let imageNSData = NSData(data: compressedImageData)
+            imageNSData.write(to: imageFilePathURL, atomically: true)
+        }
     }
     
     private func imageFilePathURL(urlString: String) -> URL? {

--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Classes/ImageManager.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Classes/ImageManager.swift
@@ -30,9 +30,10 @@ class ImageManager {
         if fileManager.fileExists(atPath: imageFilePathURL.path) {
             guard let imageData = try? Data(contentsOf: imageFilePathURL) else { return nil }
             guard let image = UIImage(data: imageData) else { return nil }
-
-            DispatchQueue.global().async { [weak self] in
-                self?.cacheImages.setObject(image, forKey: nsString)
+            
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                let imageSize = imageData.count
+                self?.cacheImages.setObject(image, forKey: nsString, cost: imageSize)
             }
 
             return image
@@ -47,8 +48,9 @@ class ImageManager {
             guard let compressedImage = UIImage(data: compressedImageData) else { return }
             
             // 메모리 캐시
+            let compressedImageSize = compressedImageData.count
             let nsString = NSString(string: urlString)
-            self?.cacheImages.setObject(compressedImage, forKey: nsString)
+            self?.cacheImages.setObject(compressedImage, forKey: nsString, cost: compressedImageSize)
             
             // 디스크 캐시
             guard let imageFilePathURL = self?.imageFilePathURL(urlString: urlString) else { return }


### PR DESCRIPTION
## 작업사항

- ImageManager의 캐시에 압축되지 않은 이미지데이터가 저장되는 오류를 해결하였습니다.

<br>

## Changes

### ImageManager의 캐시에 압축되지 않은 이미지데이터가 저장되는 오류를 해결하였습니다.
- 이제 압축된 이미지가 캐시됩니다.

<br>

## ScreenShot
### 수정 전
| 앱 시동 (홈 화면) | 사진 12장 저장되어있는 다이어리 들어갔을 때 |
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/74828662/206633924-355700d3-386f-44ef-8700-66e9b0b663a0.png" width="300" height="240"/>|<img src="https://user-images.githubusercontent.com/74828662/206633936-11c2c653-c761-4850-a6dc-3999e3bdab2a.png" width="300" height="240"/>|
### 수정 후
| 앱 시동 (홈 화면) | 사진 45장 저장되어있는 다이어리 들어갔을 때 |
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/74828662/206634024-352c7dcf-6b58-4490-b132-0decce403a24.png" width="300" height="240"/>|<img src="https://user-images.githubusercontent.com/74828662/206634040-b74ab1aa-55ca-4636-b295-8937155b769c.png" width="300" height="240"/>|

<br>

## To Reviewers
- 메모리 이슈가 전부 해결된게 아닙니다.
- 이 PR이 앱 안정성에 도움이 되지만 여전히 화면들의 메모리 해제 관련 수정이 필요합니다.


<br>

## 비고
- 없음


<br>
