### PR TITLE
[Fix] #194 StickerView 스티커 이동시 버그 수정

### DIFF
--- a/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Presenter/PageScene/View/StickerView.swift
+++ b/MacC-GoldenRatio/MacC-GoldenRatio/Sources/Presenter/PageScene/View/StickerView.swift
@@ -345,6 +345,16 @@ class StickerView: UIView {
         
     }
     
+    override internal func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        
+        guard let isStickerViewActive = try? self.isStickerViewActive.value(), isStickerViewActive == true else { return }
+
+        enableTranslucency(state: false)
+        
+        self.stickerViewData?.updateUIItem(frame: self.frame, bounds: self.bounds, transform: self.transform)
+        
+    }
+    
     override internal func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
      
         guard let isStickerViewActive = try? self.isStickerViewActive.value(), isStickerViewActive == true else { return }


### PR DESCRIPTION
## 작업사항

- StickerView 스티커 이동시 버그를 수정하였습니다.

<br>

## Changes
### StickerView 스티커 이동시 버그를 수정하였습니다.
- 터치하여 손가락을 임계치 이상을 움직이면 touchesMoved, touchesEnded 을 모두 호출합니다.
- 그러나 임계치 아래로 움직이면 touchesCancelled 메서드가 호출됩니다.
- touchesCancelled 메서드를 상속받아 작업 처리를 해줌으로써 해결하였습니다

<br>

## ScreenShot
| 수정 전 | 수정 후 |
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/74828662/206640261-3ea3bd1a-2922-4f6d-bcaa-77513616a5dd.gif" width="250" height="541"/>|<img src="https://user-images.githubusercontent.com/74828662/206640520-a1057292-bdc2-4db6-9b4f-4499389b03d4.gif" width="250" height="541"/>|

<br>

## To Reviewers
- 이 PR까지 머지되면 업데이트 진행하면 될 듯 합니다!

<br>

## 비고
- https://developer.apple.com/documentation/uikit/uiresponder#//apple_ref/occ/instm/UIResponder/touchesBegan%3awithEvent%3a